### PR TITLE
Perf: Cache default JsonSerializerOptions as static field

### DIFF
--- a/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
@@ -32,6 +32,9 @@ namespace Wolfgang.Etl.Json;
 public class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, JsonReport>
     where TRecord : notnull
 {
+    private static readonly string OperationName = $"JSON single-stream extraction of {typeof(TRecord).Name}";
+    private static readonly JsonSerializerOptions DefaultOptions = new();
+
     private readonly Stream _stream;
     private readonly JsonSerializerOptions? _options;
     private readonly ILogger _logger;
@@ -115,14 +118,14 @@ public class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, JsonRep
         [EnumeratorCancellation] CancellationToken token
     )
     {
-        JsonLogMessages.StartingOperation(_logger, $"JSON single-stream extraction of {typeof(TRecord).Name}", null);
+        JsonLogMessages.StartingOperation(_logger, OperationName, null);
 
         var skipBudget = SkipItemCount;
 
         await foreach (var item in JsonSerializer.DeserializeAsyncEnumerable<TRecord>
         (
             _stream,
-            _options ?? new JsonSerializerOptions(),
+            _options ?? DefaultOptions,
             token
         ))
         {


### PR DESCRIPTION
## Summary

- `_options ?? new JsonSerializerOptions()` in `JsonSingleStreamExtractor.ExtractWorkerAsync` allocated a new options instance on every call when no custom options were provided
- Added `private static readonly JsonSerializerOptions DefaultOptions = new()` to reuse

## Affected files
- `JsonSingleStreamExtractor.cs`

## Test plan
- [x] Build succeeds across all TFMs
- [ ] Verify tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)