### PR TITLE
Perf: Seal extractor and loader classes

### DIFF
--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -28,7 +28,7 @@ namespace Wolfgang.Etl.Json;
 /// }
 /// </code>
 /// </example>
-public class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonReport>
+public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonReport>
     where TRecord : notnull
 {
     private readonly Stream _stream;

--- a/src/Wolfgang.Etl.Json/JsonLineLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineLoader.cs
@@ -25,7 +25,7 @@ namespace Wolfgang.Etl.Json;
 /// await loader.LoadAsync(items, cancellationToken);
 /// </code>
 /// </example>
-public class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>
+public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>
     where TRecord : notnull
 {
     private readonly Stream _stream;

--- a/src/Wolfgang.Etl.Json/JsonMultiStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonMultiStreamExtractor.cs
@@ -30,7 +30,7 @@ namespace Wolfgang.Etl.Json;
 /// }
 /// </code>
 /// </example>
-public class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, JsonReport>
+public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, JsonReport>
     where TRecord : notnull
 {
     private readonly IEnumerable<Stream> _streams;

--- a/src/Wolfgang.Etl.Json/JsonMultiStreamLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonMultiStreamLoader.cs
@@ -30,7 +30,7 @@ namespace Wolfgang.Etl.Json;
 /// await loader.LoadAsync(items, cancellationToken);
 /// </code>
 /// </example>
-public class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonReport>
+public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonReport>
     where TRecord : notnull
 {
     private readonly Func<TRecord, Stream> _streamFactory;

--- a/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
@@ -29,7 +29,7 @@ namespace Wolfgang.Etl.Json;
 /// }
 /// </code>
 /// </example>
-public class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, JsonReport>
+public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, JsonReport>
     where TRecord : notnull
 {
     private readonly Stream _stream;

--- a/src/Wolfgang.Etl.Json/JsonSingleStreamLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonSingleStreamLoader.cs
@@ -24,7 +24,7 @@ namespace Wolfgang.Etl.Json;
 /// await loader.LoadAsync(items, cancellationToken);
 /// </code>
 /// </example>
-public class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonReport>
+public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonReport>
     where TRecord : notnull
 {
     private readonly Stream _stream;


### PR DESCRIPTION
## Summary

- Sealed all 6 extractor/loader classes (`JsonSingleStreamExtractor`, `JsonSingleStreamLoader`, `JsonMultiStreamExtractor`, `JsonMultiStreamLoader`, `JsonLineExtractor`, `JsonLineLoader`)
- These are not designed for inheritance — users inherit from `ExtractorBase`/`LoaderBase` directly
- Sealing allows the JIT to devirtualize method calls and skip virtual dispatch

## Test plan
- [x] Build succeeds across all TFMs
- [ ] Verify tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)