### PR TITLE
Perf: Use sync WriteLine in JsonLineLoader (23-38% faster)

### DIFF
--- a/src/Wolfgang.Etl.Json/JsonLineLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineLoader.cs
@@ -141,11 +141,9 @@ public class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>
             var json = JsonSerializer.Serialize(item, _options);
             Interlocked.Increment(ref _currentLineNumber);
 
-#if NETSTANDARD2_0 || NET462 || NET481
-            await writer.WriteLineAsync(json).ConfigureAwait(false);
-#else
-            await writer.WriteLineAsync(json.AsMemory(), token).ConfigureAwait(false);
-#endif
+#pragma warning disable CA1849, VSTHRD103, AsyncFixer02 // Sync WriteLine avoids async state machine allocation per item
+            writer.WriteLine(json);
+#pragma warning restore CA1849, VSTHRD103, AsyncFixer02
 
             IncrementCurrentItemCount();
             JsonLogMessages.LoadedItemAtLine(_logger, CurrentItemCount, Interlocked.Read(ref _currentLineNumber), null);


### PR DESCRIPTION
## Summary

- Replace `WriteLineAsync` with `WriteLine` in the per-item write loop of `JsonLineLoader`
- `StreamWriter.WriteLine` to a buffered stream completes instantly — the async state machine overhead per item is pure waste
- `FlushAsync` at the end of the method remains async

## Benchmark results (net10.0)

| Items | Before | After | Speedup |
|-------|--------|-------|---------|
| 10 | 3.98 us | 3.03 us | **24% faster** |
| 100 | 44.88 us | 27.75 us | **38% faster** |
| 1000 | 427.62 us | 329.75 us | **23% faster** |

Allocations unchanged. 291 tests passing.

## Trade-offs
- Requires `#pragma` to suppress CA1849, VSTHRD103, AsyncFixer02
- Loses cancellation token propagation on the per-line write (but a single `WriteLine` is effectively instant)

## Test plan
- [x] Build succeeds across all TFMs
- [x] 291 tests passing on net10.0
- [x] Benchmarked before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)