### PR TITLE
Fix dead code and stale reference in Setup-BranchRuleset

### DIFF
--- a/scripts/Setup-BranchRuleset.ps1
+++ b/scripts/Setup-BranchRuleset.ps1
@@ -88,19 +88,15 @@ try {
 }
 
 # Determine repository
-if ($Repository -eq "@Chris-Wolfgang/ETL-Json" -or -not $Repository) {
-    # Placeholders not replaced or no repository specified - auto-detect
+if (-not $Repository) {
+    # No repository specified - auto-detect
     Write-Host "🔍 Detecting current repository..." -ForegroundColor Cyan
     try {
         $repoInfo = gh repo view --json nameWithOwner | ConvertFrom-Json
         $Repository = $repoInfo.nameWithOwner
         Write-Host "✅ Using repository: $Repository" -ForegroundColor Green
     } catch {
-        if ($Repository -eq "@Chris-Wolfgang/ETL-Json") {
-            Write-Error "❌ Could not detect repository. Please run the setup script (pwsh ./scripts/setup.ps1) first to replace placeholders, or specify -Repository parameter."
-        } else {
-            Write-Error "❌ Could not detect repository. Please run from within a git repository or specify -Repository parameter."
-        }
+        Write-Error "❌ Could not detect repository. Please run from within a git repository or specify -Repository parameter."
         exit 1
     }
 } else {


### PR DESCRIPTION
## Summary
- Remove unreachable `@`-prefixed placeholder check in `Setup-BranchRuleset.ps1` (the `@` is already stripped on line 64, so the condition on line 91 could never be true)
- Remove stale error message referencing deleted `scripts/setup.ps1`
- Addresses Copilot review comments from PR #2

## Test plan
- [ ] Run `pwsh ./scripts/Setup-BranchRuleset.ps1` without `-Repository` to verify auto-detection still works
- [ ] Run with `-Repository "Chris-Wolfgang/ETL-Json"` to verify explicit repository still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)