### PR TITLE
Drop netcoreapp3.1 from test project target frameworks

### DIFF
--- a/tests/Wolfgang.Etl.Json.Tests.Unit/Wolfgang.Etl.Json.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/Wolfgang.Etl.Json.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net47;net471;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net462;net47;net471;net472;net48;net481;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>


### PR DESCRIPTION
## Problem
The v0.2.0 release workflow failed because GitHub Actions runners don't have .NET Core 3.1 installed (EOL since Dec 2022):

> Testhost process exited with error: You must install or update .NET to run this application.
> Framework: 'Microsoft.NETCore.App', version '3.1.0' (x64)

## Fix
Remove netcoreapp3.1 from the test project's target frameworks. The source library doesn't target netcoreapp3.1 either (it targets `net462;netstandard2.0;net8.0;net10.0`), so this doesn't reduce coverage of supported platforms.

## Test plan
- [x] Build: 0 errors, 0 warnings
- [x] All remaining TFMs still tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)