### PR TITLE
Add .NET Core 3.1 to release workflow setup-dotnet

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x
@@ -300,6 +301,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x
@@ -516,6 +518,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x


### PR DESCRIPTION
## Problem
The v0.2.0 release failed because release.yaml's `setup-dotnet` step only installs .NET 5.0+ but the test project targets `netcoreapp3.1`:

> Testhost process exited with error: You must install or update .NET to run this application.
> Framework: 'Microsoft.NETCore.App', version '3.1.0' (x64)

## Fix
Add `3.1.x` to `setup-dotnet` in all 3 jobs in release.yaml. This matches what pr.yaml already does (PR checks pass because they install 3.1.x; release fails because it didn't).

## Files changed
- `.github/workflows/release.yaml` — 3 occurrences of `dotnet-version` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)