### PR TITLE
Canonical config + workflows: protected-only PR ahead of vNext #112

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,13 +25,12 @@ indent_size = 2
 [*.{yml,yaml}]
 indent_size = 2
 
-# PowerShell files
-# PowerShell uses CRLF to maintain compatibility with Windows and PowerShell conventions
-# This overrides the global end_of_line = lf setting and aligns with .gitattributes line 14
-[*.ps1]
-indent_size = 4
-end_of_line = crlf
-charset = utf-8-bom
+# PowerShell scripts inherit LF + UTF-8 (no BOM) + 4-space indent from
+# the global [*] section above — no per-language override is needed.
+# LF + no-BOM is required for the `#!/usr/bin/env pwsh` shebang (where
+# present) on scripts under scripts/ to work on Linux/macOS — CR
+# breaks the kernel's exec lookup, and a leading BOM prevents shebang
+# recognition entirely.
 
 # C# files
 [*.cs]

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,86 @@
+name: Benchmarks
+
+# Runs BenchmarkDotNet after a merge to main, then publishes the results to
+# the gh-pages branch under /dev/bench/ where benchmark-action/github-action-benchmark
+# renders an interactive line chart.
+#
+# This workflow is decoupled from PR validation and release: it does NOT gate
+# merging or publishing — it just adds one data point per qualifying push.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'benchmarks/**'
+      - '.github/workflows/benchmarks.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    name: Run BenchmarkDotNet & publish chart
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore benchmarks/Wolfgang.Etl.Json.Benchmarks/Wolfgang.Etl.Json.Benchmarks.csproj
+
+      - name: Build (Release)
+        run: dotnet build -c Release --no-restore benchmarks/Wolfgang.Etl.Json.Benchmarks/Wolfgang.Etl.Json.Benchmarks.csproj
+
+      - name: Run benchmarks
+        working-directory: benchmarks/Wolfgang.Etl.Json.Benchmarks
+        run: dotnet run -c Release --no-build -- --filter "*" --job short --memory --exporters json
+
+      - name: Merge per-class BDN reports
+        id: locate
+        working-directory: benchmarks/Wolfgang.Etl.Json.Benchmarks
+        run: |
+          shopt -s nullglob
+          reports=(BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json)
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "::error::No BenchmarkDotNet JSON report found"
+            exit 1
+          fi
+          echo "Merging ${#reports[@]} report(s):"
+          printf '  %s\n' "${reports[@]}"
+          jq -s '{
+            Title: "BenchmarkDotNet combined report",
+            HostEnvironmentInfo: .[0].HostEnvironmentInfo,
+            Benchmarks: [.[].Benchmarks[]]
+          }' "${reports[@]}" > benchmarks-result.json
+          echo "report=benchmarks/Wolfgang.Etl.Json.Benchmarks/benchmarks-result.json" >> "$GITHUB_OUTPUT"
+
+      - name: Publish chart to gh-pages
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba  # v1.22.1
+        with:
+          name: BenchmarkDotNet
+          tool: 'benchmarkdotnet'
+          output-file-path: ${{ steps.locate.outputs.report }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          alert-threshold: '200%'
+          fail-on-alert: false

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -80,12 +80,43 @@ jobs:
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
+        # security-extended adds the broader security query pack on top of the
+        # default queries (more rules, slightly longer scans).
+        queries: security-extended
 
     - name: Setup .NET
       if: steps.check-csharp.outputs.has-csharp == 'true'
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '10.0.x'
+
+    - name: Restore .NET workloads
+      if: steps.check-csharp.outputs.has-csharp == 'true'
+      shell: pwsh
+      run: |
+        # Skip entirely if no csproj declares a workload-bearing TFM (android/ios/
+        # maccatalyst/maui/tvos/tizen/browser) — netX.Y-windows TFMs use
+        # SDK-bundled projection assemblies, not the workload installer, so
+        # they're intentionally excluded. Saves ~5-15s on pure-library
+        # repos and removes a network-dependent failure mode.
+        $hasWorkloadTfm = @(Get-ChildItem -Recurse -Filter *.csproj |
+                           Select-String -Pattern 'net\d+\.\d+-(android|ios|maccatalyst|maui|tvos|tizen|browser)' -List).Count -gt 0
+        if (-not $hasWorkloadTfm) {
+          Write-Host "No workload-bearing TFMs — skipping dotnet workload restore"
+          exit 0
+        }
+        $solution = Get-ChildItem -Path . -Recurse -Depth 2 -Include "*.sln", "*.slnx" | Select-Object -First 1
+        if ($solution) {
+          Write-Host "Restoring workloads for $($solution.FullName)"
+          dotnet workload restore "$($solution.FullName)"
+        } else {
+          Write-Host "No solution found; restoring workloads for all projects"
+          dotnet workload restore
+        }
+        if ($LASTEXITCODE -ne 0) {
+          Write-Error "dotnet workload restore failed with exit code $LASTEXITCODE"
+          exit $LASTEXITCODE
+        }
 
     - name: Build for CodeQL Analysis
       id: build

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,8 +13,6 @@
 #   for a maintainer to manually review and verify the changes before merging
 # - persist-credentials: false prevents the checkout token from being written to git config for subsequent git commands
 #   (it does NOT, by itself, prevent steps from accessing github.token / GITHUB_TOKEN if you explicitly expose it)
-# - After checkout, configuration files (.editorconfig, BannedSymbols.txt, etc.) are fetched from
-#   the main branch to prevent malicious PRs from disabling analyzers or bypassing code quality checks
 # - Default GITHUB_TOKEN permissions are restricted to read-only repository contents to limit impact if exposed
 
 name: PR Checks v3 (Gated)
@@ -51,11 +49,24 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch trusted gitleaks config from main
-        # Prevent PR from modifying .gitleaks.toml to bypass the scan
-        run: |
-          git fetch origin main --depth=1
-          git checkout origin/main -- .gitleaks.toml 2>/dev/null || true
+        # Prevent PR from modifying .gitleaks.toml to bypass the scan.
+        # Distinguish "file doesn't exist in main" (fine — gitleaks uses
+        # defaults) from "checkout failed for any other reason" (abort —
+        # silently using the PR version would defeat the guard).
         shell: bash
+        run: |
+          if ! git fetch origin main --depth=1; then
+            echo "::error::Failed to fetch origin/main — aborting before gitleaks scan."
+            exit 1
+          fi
+          if git cat-file -e origin/main:.gitleaks.toml 2>/dev/null; then
+            if ! git checkout origin/main -- .gitleaks.toml; then
+              echo "::error::Failed to checkout origin/main:.gitleaks.toml — aborting to prevent silent fall-back to PR version."
+              exit 1
+            fi
+          else
+            echo "::notice::.gitleaks.toml not present in origin/main — gitleaks will use defaults."
+          fi
 
       - name: Run gitleaks
         # gitleaks-action@v2 does not support pull_request_target, so invoke the CLI directly
@@ -117,19 +128,36 @@ jobs:
           for config_file in "${config_files[@]}"; do
             # Handle glob patterns
             if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+              # Find files matching the pattern in main branch.
+              # NOTE: use process substitution (`done < <(...)`) instead of a
+              # plain pipeline. A piped `while` runs in a subshell — an
+              # `exit 1` from inside would only kill the subshell, not the
+              # outer step, letting a failed copy silently fall back to the
+              # PR-supplied protected config. Process substitution runs the
+              # loop in the parent shell so exit actually terminates the job.
+              while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from main branch"
                   mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                  if ! git show "main-branch:$file" > "$file"; then
+                    echo "::error::Failed to copy $file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                    exit 1
+                  fi
                 fi
-              done
+              # Mask grep's exit 1 on zero matches with `|| true` — under
+              # `set -eo pipefail`, an empty match would otherwise fail the step,
+              # but a pattern like `*.ruleset` legitimately has no matches in
+              # repos that don't ship one. The empty stream is fine; the while
+              # loop simply doesn't iterate.
+              done < <(git ls-tree -r --name-only main-branch | { grep -E "${config_file//\*/.*}" || true; })
             else
               # Check if file exists in main branch
               if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
                 echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
+                if ! git show "main-branch:$config_file" > "$config_file"; then
+                  echo "::error::Failed to copy $config_file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                  exit 1
+                fi
               else
                 echo "  ℹ️  $config_file not found in main branch, skipping"
               fi
@@ -173,10 +201,13 @@ jobs:
           done
           
           # Check .globalconfig, .ruleset, and workflow files using the same git diff approach
-          # --diff-filter=AMRC: Added, Modified, Renamed, Copied (excludes Deleted)
+          # --diff-filter=AMRCD: Added, Modified, Renamed, Copied, Deleted.
+          # Including D so a PR that *deletes* a protected file (workflow,
+          # .globalconfig, .ruleset) also triggers the maintainer-review gate
+          # — a silent deletion is just as security-relevant as a silent edit.
           while IFS= read -r file; do
             changed_files+=("$file")
-          done < <(git diff --name-only --diff-filter=AMRC main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset)|^\.github/workflows/.*\.ya?ml)$' || true)
+          done < <(git diff --name-only --diff-filter=AMRCD main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset)|^\.github/workflows/.*\.ya?ml)$' || true)
           
           if [ ${#changed_files[@]} -gt 0 ]; then
             echo ""
@@ -252,74 +283,42 @@ jobs:
           for config_file in "${config_files[@]}"; do
             # Handle glob patterns
             if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+              # Find files matching the pattern in main branch.
+              # NOTE: use process substitution (`done < <(...)`) instead of a
+              # plain pipeline. A piped `while` runs in a subshell — an
+              # `exit 1` from inside would only kill the subshell, not the
+              # outer step, letting a failed copy silently fall back to the
+              # PR-supplied protected config. Process substitution runs the
+              # loop in the parent shell so exit actually terminates the job.
+              while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from main branch"
                   mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                  if ! git show "main-branch:$file" > "$file"; then
+                    echo "::error::Failed to copy $file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                    exit 1
+                  fi
                 fi
-              done
+              # Mask grep's exit 1 on zero matches with `|| true` — under
+              # `set -eo pipefail`, an empty match would otherwise fail the step,
+              # but a pattern like `*.ruleset` legitimately has no matches in
+              # repos that don't ship one. The empty stream is fine; the while
+              # loop simply doesn't iterate.
+              done < <(git ls-tree -r --name-only main-branch | { grep -E "${config_file//\*/.*}" || true; })
             else
               # Check if file exists in main branch
               if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
                 echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
+                if ! git show "main-branch:$config_file" > "$config_file"; then
+                  echo "::error::Failed to copy $config_file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                  exit 1
+                fi
               else
                 echo "  ℹ️  $config_file not found in main branch, skipping"
               fi
             fi
           done
           
-          echo ""
-          echo "✅ Configuration files secured - using versions from main branch"
-
-      - name: Fetch trusted configuration files from main branch
-        # Skip for Dependabot — its package-version bumps to protected files (e.g.
-        # Directory.Build.props) are legitimate and should not be overwritten by main's
-        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        run: |
-          echo "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          config_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-            "*.globalconfig"
-            "*.ruleset"
-            ".github/workflows/*.yml"
-            ".github/workflows/*.yaml"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          for config_file in "${config_files[@]}"; do
-            # Handle glob patterns
-            if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
-                if [ -n "$file" ]; then
-                  echo "  ✓ Copying $file from main branch"
-                  mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
-                fi
-              done
-            else
-              # Check if file exists in main branch
-              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
-                echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
-              else
-                echo "  ℹ️  $config_file not found in main branch, skipping"
-              fi
-            fi
-          done
-
           echo ""
           echo "✅ Configuration files secured - using versions from main branch"
 
@@ -349,6 +348,20 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+
+      - name: Restore .NET workloads
+        # Some projects (MAUI / MauiHybrid / Android / iOS / WPF) declare workloads via
+        # their TFMs (e.g. net10.0-android). For workload-bearing repos this installs them
+        # before restore; for pure-library repos with no workload TFMs, skip entirely to
+        # avoid ~5-15s of network-dependent setup and an extra failure mode.
+        shell: bash
+        run: |
+          if find . -name '*.csproj' -type f -exec grep -lE 'net[0-9]+\.[0-9]+-(android|ios|maccatalyst|maui|tvos|tizen|browser)' {} \; | grep -q .; then
+            echo "Workload-bearing TFMs detected — running dotnet workload restore"
+            dotnet workload restore
+          else
+            echo "No workload-bearing TFMs in any csproj — skipping dotnet workload restore"
+          fi
 
       - name: Restore and build (exclude .NET Framework-only projects)
         run: |
@@ -449,15 +462,27 @@ jobs:
           # Gracefully skip if there is no ./tests directory (e.g. template-publishing
           # repos or library repos in early development that have no tests yet).
           # The downstream coverage steps already handle the no-coverage-files case.
+          # Fail loudly if the repo HAS src/ projects — the coverage gate
+          # exists to enforce test coverage on shipping code, so silently
+          # passing when tests are missing is the wrong default. Skip only
+          # for template-pack / in-dev repos with no source projects yet.
           if [ ! -d ./tests ]; then
-            echo "ℹ️  No ./tests directory — skipping test stage."
+            if find ./src -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print -quit 2>/dev/null | grep -q .; then
+              echo "❌ ./tests directory is missing but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            fi
+            echo "ℹ️  No ./tests directory and no ./src projects — skipping test stage (template-pack / in-dev shape)."
             exit 0
           fi
 
-          mapfile -d '' -t test_projects < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
+          mapfile -d '' -t test_projects < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -not -name "*.Tests.Integration.*" -print0)
 
           if [ ${#test_projects[@]} -eq 0 ]; then
-            echo "ℹ️  No test projects found under ./tests — skipping test stage."
+            if find ./src -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print -quit 2>/dev/null | grep -q .; then
+              echo "❌ No test projects under ./tests but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            fi
+            echo "ℹ️  No test projects found under ./tests and no ./src projects — skipping test stage (template-pack / in-dev shape)."
             exit 0
           fi
           
@@ -500,6 +525,7 @@ jobs:
               dotnet test "$test_proj" \
                 --configuration Release \
                 --framework "$fw" \
+                --no-build --no-restore \
                 --collect:"XPlat Code Coverage" \
                 --settings coverlet.runsettings \
                 --results-directory "./TestResults" \
@@ -545,15 +571,24 @@ jobs:
           
           failed_projects=""
           threshold=${CODECOV_MINIMUM:-90}
-          
+          matched_count=0
+
           while read -r line; do
-            # Match lines with module names and percentages
-            if echo "$line" | grep -qE '^[^ ].*[0-9]+%$' && ! echo "$line" | grep -q '^Summary'; then
+            # Match lines with module names and percentages. The percent
+            # capture is the LAST %-suffixed number on the line, matching
+            # Stage 2's behavior — ReportGenerator Summary.txt rows often
+            # have line/branch/method columns and the overall figure is at
+            # end-of-line.
+            if echo "$line" | grep -qE '^[^ ].*[0-9]+(\.[0-9]+)?%$' && ! echo "$line" | grep -q '^Summary'; then
               module=$(echo "$line" | awk '{print $1}')
-              percent=$(echo "$line" | awk '{print $NF}' | tr -d '%')
-              
+              # Floor the percent to int (matches Stage 2 pwsh's [int][math]::Floor)
+              # so we can use bash's integer -lt comparator below without
+              # erroring on decimals like "90.4".
+              percent=$(echo "$line" | awk '{print $NF}' | tr -d '%' | awk '{print int($1)}')
+              matched_count=$((matched_count + 1))
+
               echo "Checking module: '$module' - Coverage: ${percent}%"
-              
+
               if [ "$percent" -lt "$threshold" ]; then
                 echo "  ❌ FAIL: Below ${threshold}% threshold"
                 failed_projects="$failed_projects $module (${percent}%)"
@@ -562,6 +597,14 @@ jobs:
               fi
             fi
           done < CoverageReport/Summary.txt
+
+          # Fail loudly when 0 modules matched - the regex is wrong or
+          # Summary.txt format changed. Silently passing the gate when we
+          # couldn't parse coverage is worse than failing.
+          if [ "$matched_count" -eq 0 ]; then
+            echo "❌ Coverage parser matched 0 modules in Summary.txt - regex or report format is out of sync. Refusing to silently pass the gate."
+            exit 1
+          fi
 
           if [ -n "$failed_projects" ]; then
             echo ""
@@ -615,6 +658,10 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         shell: pwsh
         run: |
           Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
@@ -636,7 +683,7 @@ jobs:
             $exists = git cat-file -e "main-branch:$configFile" 2>&1
             if ($LASTEXITCODE -eq 0) {
               Write-Host "  ✓ Copying $configFile from main branch"
-              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8 -NoNewline
+              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM
             } else {
               Write-Host "  ℹ️  $configFile not found in main branch, skipping"
             }
@@ -651,56 +698,11 @@ jobs:
                 Write-Host "  ✓ Copying $file from main branch"
                 $dir = Split-Path -Parent $file
                 if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8 -NoNewline
+                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM
               }
             }
           }
           
-          Write-Host ""
-          Write-Host "✅ Configuration files secured - using versions from main branch"
-
-      - name: Fetch trusted configuration files from main branch
-        shell: pwsh
-        run: |
-          Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          $configFiles = @(
-            ".editorconfig",
-            "Directory.Build.props",
-            "Directory.Build.targets",
-            "BannedSymbols.txt"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          foreach ($configFile in $configFiles) {
-            # Check if file exists in main branch
-            $exists = git cat-file -e "main-branch:$configFile" 2>&1
-            if ($LASTEXITCODE -eq 0) {
-              Write-Host "  ✓ Copying $configFile from main branch"
-              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8 -NoNewline
-            } else {
-              Write-Host "  ℹ️  $configFile not found in main branch, skipping"
-            }
-          }
-
-          # Handle glob patterns for .globalconfig, .ruleset, and workflow files
-          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
-          foreach ($pattern in $globPatterns) {
-            $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
-            foreach ($file in $files) {
-              if ($file) {
-                Write-Host "  ✓ Copying $file from main branch"
-                $dir = Split-Path -Parent $file
-                if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8 -NoNewline
-              }
-            }
-          }
-
           Write-Host ""
           Write-Host "✅ Configuration files secured - using versions from main branch"
 
@@ -716,6 +718,20 @@ jobs:
             9.0.x
             10.0.x
 
+      - name: Restore .NET workloads
+        # Some projects (MAUI / MauiHybrid / Android / iOS / WPF) declare workloads via
+        # their TFMs (e.g. net10.0-android). For workload-bearing repos this installs them
+        # before restore; for pure-library repos with no workload TFMs, skip entirely to
+        # avoid ~5-15s of network-dependent setup and an extra failure mode.
+        shell: bash
+        run: |
+          if find . -name '*.csproj' -type f -exec grep -lE 'net[0-9]+\.[0-9]+-(android|ios|maccatalyst|maui|tvos|tizen|browser)' {} \; | grep -q .; then
+            echo "Workload-bearing TFMs detected — running dotnet workload restore"
+            dotnet workload restore
+          else
+            echo "No workload-bearing TFMs in any csproj — skipping dotnet workload restore"
+          fi
+
       - name: Restore dependencies
         run: dotnet restore
 
@@ -729,15 +745,29 @@ jobs:
 
           # Gracefully skip if there is no ./tests directory (e.g. template-publishing
           # repos or library repos in early development that have no tests yet).
+          # The coverage gate exists to enforce test coverage on shipping
+          # code. If ./src has projects but ./tests doesn't, fail loudly
+          # instead of silently passing the gate. Skip only for template-
+          # pack / in-dev repos that have no source projects yet.
+          $srcHasProjects = @(Get-ChildItem -Path './src' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj' -ErrorAction SilentlyContinue).Count -gt 0
+
           if (-not (Test-Path -Path './tests' -PathType Container)) {
-            Write-Host "ℹ️  No ./tests directory — skipping test stage."
+            if ($srcHasProjects) {
+              Write-Error "❌ ./tests directory is missing but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            }
+            Write-Host "ℹ️  No ./tests directory and no ./src projects — skipping test stage (template-pack / in-dev shape)."
             exit 0
           }
 
           $testProjects = @(Get-ChildItem -Path './tests/*' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj')
 
           if (@($testProjects).Count -eq 0) {
-            Write-Host "ℹ️  No test projects found under ./tests — skipping test stage."
+            if ($srcHasProjects) {
+              Write-Error "❌ No test projects under ./tests but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            }
+            Write-Host "ℹ️  No test projects found under ./tests and no ./src projects — skipping test stage (template-pack / in-dev shape)."
             exit 0
           }
           
@@ -786,6 +816,7 @@ jobs:
                 dotnet test $testProj.FullName `
                   --configuration Release `
                   --framework $fw `
+                  --no-build --no-restore `
                   --collect:"XPlat Code Coverage" `
                   --settings coverlet.runsettings `
                   --results-directory "./TestResults" `
@@ -794,6 +825,7 @@ jobs:
                 dotnet test $testProj.FullName `
                   --configuration Release `
                   --framework $fw `
+                  --no-build --no-restore `
                   --logger "console;verbosity=normal"
               }
 
@@ -845,11 +877,34 @@ jobs:
 
           $threshold = if ($env:CODECOV_MINIMUM) { [int]$env:CODECOV_MINIMUM } else { 90 }
           $failedProjects = @()
+          $matchedCount   = 0
 
           foreach ($line in (Get-Content "CoverageReport/Summary.txt")) {
-            if ($line -match '^\s*(\S+)\s+(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^\s*Summary') {
+            # Only consider top-level assembly rows: non-space first char,
+            # then anything, then whitespace + the final percent at EOL.
+            # Matches Stage 1's `^[^ ].*[0-9]+(\.[0-9]+)?%$` filter (which
+            # uses awk $NF for the percent — robust to extra columns like
+            # line/branch/method that ReportGenerator can emit on the same
+            # row).
+            #
+            # Bug previously here: a `.*` between the module name and the
+            # trailing `(\d+)%` was greedy and could eat all but the last
+            # digit of the percent — turning "100" into "0" and failing
+            # the gate on actually-100%-covered modules. Two changes:
+            #  - Anchor on `^(\S+)` so indented sub-class rows are skipped
+            #    (their parent assembly row carries the same number, so
+            #    nothing is lost — and Stage 1 ignores them too).
+            #  - Require whitespace immediately before the final `\d+%`
+            #    (`\s(\d+...)%\s*$`). This still allows intermediate
+            #    columns between the module name and the final percent
+            #    (the `.*` consumes them), but `.*` can't terminate
+            #    mid-digit-run — the regex engine MUST place `\s` before
+            #    the digits, which forces the last %-suffixed number on
+            #    the line to be captured intact.
+            if ($line -match '^(\S+).*\s(\d+(?:\.\d+)?)%\s*$' -and $line -notmatch '^Summary') {
               $module  = $Matches[1]
               $percent = [int][math]::Floor([double]$Matches[2])
+              $matchedCount++
 
               Write-Host "Checking module: '$module' - Coverage: ${percent}%"
 
@@ -860,6 +915,14 @@ jobs:
                 Write-Host "  ✅ PASS: Meets ${threshold}% threshold" -ForegroundColor Green
               }
             }
+          }
+
+          # Fail loudly when 0 modules matched — the regex is wrong or
+          # Summary.txt format changed. Silently passing the gate when we
+          # couldn't read coverage is worse than failing.
+          if ($matchedCount -eq 0) {
+            Write-Error "❌ Coverage parser matched 0 modules in Summary.txt — regex or report format is out of sync. Refusing to silently pass the gate."
+            exit 1
           }
 
           if ($failedProjects.Count -gt 0) {
@@ -932,74 +995,42 @@ jobs:
           for config_file in "${config_files[@]}"; do
             # Handle glob patterns
             if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+              # Find files matching the pattern in main branch.
+              # NOTE: use process substitution (`done < <(...)`) instead of a
+              # plain pipeline. A piped `while` runs in a subshell — an
+              # `exit 1` from inside would only kill the subshell, not the
+              # outer step, letting a failed copy silently fall back to the
+              # PR-supplied protected config. Process substitution runs the
+              # loop in the parent shell so exit actually terminates the job.
+              while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from main branch"
                   mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                  if ! git show "main-branch:$file" > "$file"; then
+                    echo "::error::Failed to copy $file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                    exit 1
+                  fi
                 fi
-              done
+              # Mask grep's exit 1 on zero matches with `|| true` — under
+              # `set -eo pipefail`, an empty match would otherwise fail the step,
+              # but a pattern like `*.ruleset` legitimately has no matches in
+              # repos that don't ship one. The empty stream is fine; the while
+              # loop simply doesn't iterate.
+              done < <(git ls-tree -r --name-only main-branch | { grep -E "${config_file//\*/.*}" || true; })
             else
               # Check if file exists in main branch
               if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
                 echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
+                if ! git show "main-branch:$config_file" > "$config_file"; then
+                  echo "::error::Failed to copy $config_file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                  exit 1
+                fi
               else
                 echo "  ℹ️  $config_file not found in main branch, skipping"
               fi
             fi
           done
           
-          echo ""
-          echo "✅ Configuration files secured - using versions from main branch"
-
-      - name: Fetch trusted configuration files from main branch
-        # Skip for Dependabot — its package-version bumps to protected files (e.g.
-        # Directory.Build.props) are legitimate and should not be overwritten by main's
-        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        run: |
-          echo "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          config_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-            "*.globalconfig"
-            "*.ruleset"
-            ".github/workflows/*.yml"
-            ".github/workflows/*.yaml"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          for config_file in "${config_files[@]}"; do
-            # Handle glob patterns
-            if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
-                if [ -n "$file" ]; then
-                  echo "  ✓ Copying $file from main branch"
-                  mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
-                fi
-              done
-            else
-              # Check if file exists in main branch
-              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
-                echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
-              else
-                echo "  ℹ️  $config_file not found in main branch, skipping"
-              fi
-            fi
-          done
-
           echo ""
           echo "✅ Configuration files secured - using versions from main branch"
 
@@ -1012,6 +1043,20 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+
+      - name: Restore .NET workloads
+        # Some projects (MAUI / MauiHybrid / Android / iOS / WPF) declare workloads via
+        # their TFMs (e.g. net10.0-android). For workload-bearing repos this installs them
+        # before restore; for pure-library repos with no workload TFMs, skip entirely to
+        # avoid ~5-15s of network-dependent setup and an extra failure mode.
+        shell: bash
+        run: |
+          if find . -name '*.csproj' -type f -exec grep -lE 'net[0-9]+\.[0-9]+-(android|ios|maccatalyst|maui|tvos|tizen|browser)' {} \; | grep -q .; then
+            echo "Workload-bearing TFMs detected — running dotnet workload restore"
+            dotnet workload restore
+          else
+            echo "No workload-bearing TFMs in any csproj — skipping dotnet workload restore"
+          fi
 
       - name: Restore and build (exclude .NET Framework-only projects)
         run: |
@@ -1110,18 +1155,30 @@ jobs:
           # Find all test projects (C#, VB.NET, F#).
           # Gracefully skip if there is no ./tests directory (e.g. template-publishing
           # repos or library repos in early development that have no tests yet).
+          # Fail loudly if the repo HAS src/ projects — the coverage gate
+          # exists to enforce test coverage on shipping code, so silently
+          # passing when tests are missing is the wrong default. Skip only
+          # for template-pack / in-dev repos with no source projects yet.
           if [ ! -d ./tests ]; then
-            echo "ℹ️  No ./tests directory — skipping test stage."
+            if find ./src -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print -quit 2>/dev/null | grep -q .; then
+              echo "❌ ./tests directory is missing but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            fi
+            echo "ℹ️  No ./tests directory and no ./src projects — skipping test stage (template-pack / in-dev shape)."
             exit 0
           fi
 
           test_projects=()
           while IFS= read -r -d '' file; do
           test_projects+=("$file")
-          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
+          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -not -name "*.Tests.Integration.*" -print0)
 
           if [ ${#test_projects[@]} -eq 0 ]; then
-            echo "ℹ️  No test projects found under ./tests — skipping test stage."
+            if find ./src -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print -quit 2>/dev/null | grep -q .; then
+              echo "❌ No test projects under ./tests but ./src contains projects — refusing to silently skip the coverage gate."
+              exit 1
+            fi
+            echo "ℹ️  No test projects found under ./tests and no ./src projects — skipping test stage (template-pack / in-dev shape)."
             exit 0
           fi
           
@@ -1165,6 +1222,7 @@ jobs:
               dotnet test "$test_proj" \
                 --configuration Release \
                 --framework "$fw" \
+                --no-build --no-restore \
                 --collect:"XPlat Code Coverage" \
                 --settings coverlet.runsettings \
                 --results-directory "./TestResults" \
@@ -1189,8 +1247,17 @@ jobs:
 
       - name: Enforce 90% coverage threshold
         run: |
+          # If no cobertura files were produced (no tests, all test projects
+          # skipped, etc.), the preceding step explicitly skipped report
+          # generation. Mirror that here — gating only when coverage was
+          # actually collected — instead of failing with "Coverage report
+          # not generated!" on jobs that legitimately had nothing to cover.
+          if ! find ./TestResults -name "coverage.cobertura.xml" -print -quit 2>/dev/null | grep -q .; then
+            echo "ℹ️  No coverage files produced — skipping coverage gate (consistent with the prior 'skipping report generation' notice)."
+            exit 0
+          fi
           if [ ! -f "CoverageReport/Summary.txt" ]; then
-            echo "❌ Coverage report not generated!"
+            echo "❌ Coverage files exist but Summary.txt is missing — ReportGenerator failed."
             exit 1
           fi
 
@@ -1315,74 +1382,42 @@ jobs:
           for config_file in "${config_files[@]}"; do
             # Handle glob patterns
             if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+              # Find files matching the pattern in main branch.
+              # NOTE: use process substitution (`done < <(...)`) instead of a
+              # plain pipeline. A piped `while` runs in a subshell — an
+              # `exit 1` from inside would only kill the subshell, not the
+              # outer step, letting a failed copy silently fall back to the
+              # PR-supplied protected config. Process substitution runs the
+              # loop in the parent shell so exit actually terminates the job.
+              while read -r file; do
                 if [ -n "$file" ]; then
                   echo "  ✓ Copying $file from main branch"
                   mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                  if ! git show "main-branch:$file" > "$file"; then
+                    echo "::error::Failed to copy $file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                    exit 1
+                  fi
                 fi
-              done
+              # Mask grep's exit 1 on zero matches with `|| true` — under
+              # `set -eo pipefail`, an empty match would otherwise fail the step,
+              # but a pattern like `*.ruleset` legitimately has no matches in
+              # repos that don't ship one. The empty stream is fine; the while
+              # loop simply doesn't iterate.
+              done < <(git ls-tree -r --name-only main-branch | { grep -E "${config_file//\*/.*}" || true; })
             else
               # Check if file exists in main branch
               if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
                 echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
+                if ! git show "main-branch:$config_file" > "$config_file"; then
+                  echo "::error::Failed to copy $config_file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                  exit 1
+                fi
               else
                 echo "  ℹ️  $config_file not found in main branch, skipping"
               fi
             fi
           done
           
-          echo ""
-          echo "✅ Configuration files secured - using versions from main branch"
-
-      - name: Fetch trusted configuration files from main branch
-        # Skip for Dependabot — its package-version bumps to protected files (e.g.
-        # Directory.Build.props) are legitimate and should not be overwritten by main's
-        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        run: |
-          echo "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          config_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-            "*.globalconfig"
-            "*.ruleset"
-            ".github/workflows/*.yml"
-            ".github/workflows/*.yaml"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          for config_file in "${config_files[@]}"; do
-            # Handle glob patterns
-            if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
-                if [ -n "$file" ]; then
-                  echo "  ✓ Copying $file from main branch"
-                  mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
-                fi
-              done
-            else
-              # Check if file exists in main branch
-              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
-                echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
-              else
-                echo "  ℹ️  $config_file not found in main branch, skipping"
-              fi
-            fi
-          done
-
           echo ""
           echo "✅ Configuration files secured - using versions from main branch"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -562,10 +562,107 @@ jobs:
           retention-days: 90
           if-no-files-found: warn
 
+  # Verify the documentation builds cleanly BEFORE publishing the release —
+  # initiative D8. Builds DocFX without deploying so a docs failure blocks
+  # publish-nuget rather than landing after the package is already live.
+  verify-docs-build:
+    name: Verify Documentation Builds
+    runs-on: windows-latest
+    # Gate on the prior validation jobs so we don't burn ~5-10 min of Windows
+    # runner time on a release that's already failing earlier in the pipeline.
+    needs: [validate-release, pack-and-validate]
+    if: github.repository != 'Chris-Wolfgang/repo-template'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Detect docfx project
+        id: check
+        shell: pwsh
+        run: |
+          if (Test-Path "docfx_project/docfx.json") {
+            "found=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          } else {
+            Write-Host "::notice::No docfx_project/docfx.json - skipping docs verification."
+            "found=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          }
+
+      - name: Setup .NET
+        if: steps.check.outputs.found == 'true'
+        uses: actions/setup-dotnet@v5
+        with:
+          # Install the same SDK set as validate-release so dotnet build can
+          # compile every TFM the solution targets (some test projects span
+          # netcoreapp3.1 → net10.0). Without these, the docs verify step
+          # fails on repos with broad multi-targeting.
+          dotnet-version: |
+            3.1.x
+            5.0.x
+            6.0.x
+            7.0.x
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Restore .NET workloads
+        # Same gated probe as pr.yaml — only run dotnet workload restore when
+        # at least one csproj declares a workload-bearing TFM. Required for
+        # repos with MAUI/Android/iOS targets (e.g. Hawsey); fast no-op
+        # otherwise. Without this, dotnet build below fails on workload-bearing
+        # projects because the SDK can't resolve the workload assemblies.
+        if: steps.check.outputs.found == 'true'
+        shell: bash
+        run: |
+          if find . -name '*.csproj' -type f -exec grep -lE 'net[0-9]+\.[0-9]+-(android|ios|maccatalyst|maui|tvos|tizen|browser)' {} \; | grep -q .; then
+            echo "Workload-bearing TFMs detected — running dotnet workload restore"
+            dotnet workload restore
+          else
+            echo "No workload-bearing TFMs in any csproj — skipping dotnet workload restore"
+          fi
+
+      - name: Restore dependencies
+        if: steps.check.outputs.found == 'true'
+        run: dotnet restore
+
+      - name: Build solution (Release)
+        if: steps.check.outputs.found == 'true'
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Install DocFX
+        if: steps.check.outputs.found == 'true'
+        shell: pwsh
+        run: dotnet tool update docfx --global || dotnet tool install docfx --global
+
+      - name: Build DocFX metadata
+        if: steps.check.outputs.found == 'true'
+        run: docfx metadata
+        working-directory: docfx_project
+
+      - name: Build documentation (no deploy)
+        if: steps.check.outputs.found == 'true'
+        run: docfx build
+        working-directory: docfx_project
+
+      - name: Verify documentation output
+        if: steps.check.outputs.found == 'true'
+        shell: pwsh
+        run: |
+          if (-Not (Test-Path "docfx_project/_site")) {
+            Write-Error "docfx_project/_site not found after build"
+            exit 1
+          }
+          if (-Not (Test-Path "docfx_project/_site/api")) {
+            Write-Error "docfx_project/_site/api not found - API metadata generation may have failed"
+            exit 1
+          }
+          Write-Host "Documentation built successfully - release may proceed"
+
   # Publish to NuGet (only if validation passed)
   publish-nuget:
     name: Publish to NuGet.org
-    needs: pack-and-validate
+    needs: [pack-and-validate, verify-docs-build]
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
     steps:
@@ -674,6 +771,7 @@ jobs:
           tag_name: ${{ github.event.release.tag_name }}
           files: |
             ./nuget-packages/*.nupkg
+            ./nuget-packages/*.snupkg
             ./nuget-packages/*.bom.json
             release-coverage.zip
 

--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -1,0 +1,107 @@
+# Stryker mutation testing
+#
+# Runs the Stryker.NET mutation tester against the repo's test projects to
+# measure mutation score. Mutation runs are slow — triggered manually
+# (workflow_dispatch) and on a weekly schedule, not on every PR.
+#
+# The workflow looks for a stryker-config.json at the repo root or under
+# tests/**/. If none is present the run is a no-op (Stryker setup is a
+# per-repo follow-up; this file is the canonical infrastructure).
+name: Stryker (mutation testing)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 0' # weekly Sunday 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  stryker:
+    name: Run Stryker
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Detect stryker-config.json
+        id: check
+        shell: bash
+        run: |
+          # Explicit existence checks rather than globbing — `nullglob` only
+          # drops words that look like patterns (contain *, ?, [). The bare
+          # literal `stryker-config.json` has no glob characters, so it would
+          # be preserved as a literal even when the file doesn't exist, and
+          # the workflow would mistakenly think a config was present.
+          shopt -s globstar nullglob
+          configs=()
+          [ -f stryker-config.json ] && configs+=(stryker-config.json)
+          for cfg in tests/**/stryker-config.json; do
+            [ -f "$cfg" ] && configs+=("$cfg")
+          done
+          if (( ${#configs[@]} )); then
+            printf 'found=true\n' >> "$GITHUB_OUTPUT"
+            # NOTE: previously also wrote a configs<<EOF multi-line output here,
+            # but (a) the downstream Run Stryker step re-globs from scratch and
+            # didn't consume it, and (b) ${configs[*]} joins with spaces so the
+            # value was effectively a single space-separated line — not actually
+            # multi-line. Dropped the dead/broken output.
+          else
+            echo "::notice::No stryker-config.json found — skipping Stryker run. Add one at repo root or under tests/<project>/ to enable mutation testing."
+            printf 'found=false\n' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.check.outputs.found == 'true'
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Install dotnet-stryker
+        if: steps.check.outputs.found == 'true'
+        run: dotnet tool update -g dotnet-stryker || dotnet tool install -g dotnet-stryker
+
+      - name: Run Stryker
+        if: steps.check.outputs.found == 'true'
+        shell: bash
+        run: |
+          set -e
+          shopt -s globstar nullglob
+          # Run BOTH a root stryker-config.json (if present) AND any
+          # tests/**/stryker-config.json suites. The Detect step collects
+          # both shapes; running only one leaves per-test suites unscanned
+          # in repos that have both an umbrella and per-suite configs.
+          ran=0
+          if [ -f stryker-config.json ]; then
+            echo "::group::Stryker with root stryker-config.json"
+            dotnet stryker --config-file stryker-config.json
+            echo "::endgroup::"
+            ran=1
+          fi
+          for cfg in tests/**/stryker-config.json; do
+            dir=$(dirname "$cfg")
+            echo "::group::Stryker in $dir"
+            (cd "$dir" && dotnet stryker)
+            echo "::endgroup::"
+            ran=1
+          done
+          if [ "$ran" -eq 0 ]; then
+            echo "::error::Detect step said stryker-config.json was present, but Run found neither root nor tests/**/stryker-config.json. Bailing."
+            exit 1
+          fi
+
+      - name: Upload Stryker report
+        if: always() && steps.check.outputs.found == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: stryker-report-${{ github.run_id }}
+          path: |
+            **/StrykerOutput/**
+          if-no-files-found: ignore
+          retention-days: 30

--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -79,4 +79,3 @@ M:System.Console.ReadLine(); Blocking - avoid in async code paths
 M:System.Console.Read(); Blocking - avoid in async code paths
 M:System.Console.ReadKey(); Blocking - avoid in async code paths
 M:System.Console.ReadKey(System.Boolean); Blocking - avoid in async code paths
-

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,14 @@
 <Project>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
+    <!-- Enable nullable reference types for every SDK-style C# project.
+         The condition excludes:
+           - F# (.fsproj) and VB (.vbproj) — by the .csproj check
+           - Legacy non-SDK csproj (no Microsoft.NET.Sdk import) — by the
+             $(UsingMicrosoftNETSdk) check
+         SDK-style C# projects that need to opt out can set
+         <Nullable>disable</Nullable> in their own csproj. -->
+    <Nullable Condition="'$(MSBuildProjectExtension)' == '.csproj' and '$(UsingMicrosoftNETSdk)' == 'true'">enable</Nullable>
 
     <!-- Enable .NET analyzers -->
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
@@ -56,4 +64,49 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- A1: PublicApiAnalyzers — track public API surface for breaking-change
+         detection. AdditionalFiles below are opt-in PER PROJECT via Exists():
+         drop PublicAPI.Shipped.txt + PublicAPI.Unshipped.txt into a src
+         project directory and the analyzer activates for that project only.
+         Library projects under src/ should opt in; test / example /
+         benchmark projects should not. Per-repo enablement is tracked as a
+         follow-up maintenance issue. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" Condition="Exists('PublicAPI.Shipped.txt')" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" Condition="Exists('PublicAPI.Unshipped.txt')" />
+  </ItemGroup>
+
+
+  <PropertyGroup>
+    <!-- CI3: NuGet package metadata canonical defaults. Per-repo fields
+         (Description, PackageTags, PackageProjectUrl, RepositoryUrl,
+         PackageLicenseExpression, PackageReadmeFile) stay in each src
+         csproj where they are repo-specific. -->
+    <Authors>Chris Wolfgang</Authors>
+    <Company>Chris Wolfgang</Company>
+    <Copyright>Copyright (c) Chris Wolfgang</Copyright>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- SourceLink: embed source provenance into PDBs so debuggers can step
+         into NuGet package code from GitHub. -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Why protected-only

PR #112 (`vNext → main`, v0.2.1) is `MERGEABLE` but `BLOCKED` solely by **Detect .NET Projects**, because it modifies 8 protected configuration files. Rather than admin-bypassing the *entire* release diff (which waives review-thread enforcement on everything), this PR isolates just those 8 files so the bypass is small, reviewable, and full ruleset enforcement still applies to #112.

## Protected files (all from vNext, unchanged)

- `.editorconfig`
- `Directory.Build.props`
- `BannedSymbols.txt`
- `.github/workflows/benchmarks.yaml`
- `.github/workflows/codeql.yaml`
- `.github/workflows/pr.yaml`
- `.github/workflows/release.yaml`
- `.github/workflows/stryker.yaml`

## Expected CI

- **Detect .NET Projects** ❌ — by design; this is the guard doing its job. Stage 1/2/3 will SKIP as a consequence.
- Secrets Scan / DevSkim / CodeQL ✅

## Merge path

A maintainer reviews the 8 files and **admin-bypass-merges** this PR. Once it lands on `main`, I'll merge `main` back into `vNext` — the protected-file delta disappears and **#112** flips to mergeable through the normal merge button (no bypass).

Source release PR: #112