### PR TITLE
docs: clickable Actions-tab link in RELEASE-WORKFLOW-SETUP

### DIFF
--- a/docs/RELEASE-WORKFLOW-SETUP.md
+++ b/docs/RELEASE-WORKFLOW-SETUP.md
@@ -212,7 +212,7 @@ Before creating a production GitHub Release (e.g., `v1.0.0`):
 
 If you encounter issues not covered in this guide:
 
-1. Check the Actions tab of this repository on GitHub for detailed logs
+1. Check the [Actions tab](../../actions) for detailed logs
 2. Review artifacts uploaded by failed jobs
 3. Consult the [GitHub Actions documentation](https://docs.github.com/en/actions)
 4. Open an issue in this repository with:


### PR DESCRIPTION
One-line salvage from #160: turns the plain-text "Actions tab of this repository on GitHub" reference into a relative `[Actions tab](../../actions)` link.

The rest of #160 was stale (it would have reverted `README-FORMATTING.md` and `WORKFLOW_SECURITY.md` to incorrect content vs the canonical docs already on main), so #160 is closed and this is the only piece worth keeping.