### PR TITLE
fix(scripts): gitleaks tar reads from stdin (#73 template drift)

### DIFF
--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -302,7 +302,11 @@ if (-not $SkipSecurity) {
             # is on PATH by default on most Linux distros and macOS; if not, prepend it.
             $localBin = Join-Path $HOME ".local/bin"
             New-Item -ItemType Directory -Force -Path $localBin | Out-Null
-            curl -sSfL $url | tar xz -C $localBin gitleaks
+            # Use 'tar -f -' so extraction reads the gitleaks archive from
+            # stdin. GNU tar without '-f' defaults to /dev/tape (or another
+            # default depending on the TAPE env var), which can hang silently
+            # in CI / fresh shells.
+            curl -sSfL $url | tar -xz -f - -C $localBin gitleaks
             if (-not ($env:PATH -split [IO.Path]::PathSeparator | Where-Object { $_ -eq $localBin })) {
                 $env:PATH = "$localBin$([IO.Path]::PathSeparator)$env:PATH"
             }


### PR DESCRIPTION
Syncs the one genuine template-drift fix for #73: `scripts/build-pr.ps1` piped the gitleaks tarball to `tar xz` without `-f -`. GNU tar without `-f` defaults to `/dev/tape` and can hang silently in CI / fresh shells. Template already has this fix; `pr.yaml` was never affected (it extracts from a downloaded file with `-f "$TARBALL"`).

Part of #73. Remaining drift after this is all intentional/expected (placeholder substitutions, repo-specific SDK/docfx content, ETL-Json-ahead canonical workflows, and post-setup bootstrap scripts deleted by design).