### PR TITLE
docs: fix README header + analyzer list accuracy (#89, #86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ Test coverage spans: .NET Framework 4.6.2 through 4.8.1, .NET Core 3.1, .NET 5.0
 
 ---
 
-## 🔍 Code Quality ## Code Quality & Static Analysis Static Analysis
+## 🔍 Code Quality & Static Analysis
 
-This project enforces strict code quality standards through 7 specialized analyzers and custom async-first rules:
+This project enforces strict code quality standards through 8 specialized analyzers and custom async-first rules:
 
 ### Analyzers in Use
 
@@ -161,6 +161,7 @@ This project enforces strict code quality standards through 7 specialized analyz
 5. **Microsoft.CodeAnalysis.BannedApiAnalyzers** - Prevents usage of banned synchronous APIs
 6. **Meziantou.Analyzer** - Comprehensive code quality rules
 7. **SonarAnalyzer.CSharp** - Industry-standard code analysis
+8. **Microsoft.CodeAnalysis.PublicApiAnalyzers** - Tracks the public API surface to catch unintended breaking changes
 
 ### Async-First Enforcement
 


### PR DESCRIPTION
Addresses #89 (audit README for accuracy) and the structural defect in #86:

- **Fixed garbled heading** at the Code Quality section (`## 🔍 Code Quality ## Code Quality & Static Analysis Static Analysis` → `## 🔍 Code Quality & Static Analysis`).
- **Analyzer list now accurate**: bumped 7 → 8 and added `Microsoft.CodeAnalysis.PublicApiAnalyzers`, which was added to the build in the v0.2.1 A1 work (#97).

Verified accurate (no change needed): the Target Frameworks table matches the csproj (`net462;net481;netstandard2.0;net8.0;net10.0`), and all Quick Start constructor signatures match the public ctors.

Docs-only, no protected files.