### PR TITLE
fix: ConfigureAwait(false) on JsonSingleStreamExtractor (#79 review finding)

### DIFF
--- a/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading;
+using System.Threading.Tasks;
 using System.IO;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -197,7 +198,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
             ? JsonSerializer.DeserializeAsyncEnumerable(_stream, _typeInfo, token)
             : JsonSerializer.DeserializeAsyncEnumerable<TRecord>(_stream, _options ?? DefaultOptions, token);
 
-        await foreach (var item in enumerable)
+        await foreach (var item in enumerable.WithCancellation(token).ConfigureAwait(false))
         {
             token.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
From the #79 full code-review pass.

`JsonSingleStreamExtractor.ExtractWorkerAsync` was the only extractor/loader whose `await foreach` didn't suppress the synchronization context — the three loaders all use `.WithCancellation(token).ConfigureAwait(false)`. Root cause: the file was missing `using System.Threading.Tasks;`, so neither `WithCancellation` nor `ConfigureAwait` was even available, and the original just wrote `await foreach (var item in enumerable)`.

CA2007 doesn't flag the bare `await foreach` form, so it passed CI — but it matters for the **net462 / netstandard2.0** targets, where capturing a consumer's sync context can deadlock.

Added the using and matched the canonical pattern. Build 0 warnings / 0 errors across all TFMs; 346 tests pass.

This was the only new finding from the review — the rest of the codebase is clean (other doc/metadata/drift items were addressed in #157/#163/#164/#165/#166).