### PR TITLE
test: add integration test suite (#84)

### DIFF
--- a/ETL Json.slnx
+++ b/ETL Json.slnx
@@ -46,6 +46,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Wolfgang.Etl.Json.Tests.Unit/Wolfgang.Etl.Json.Tests.Unit.csproj" />
+    <Project Path="tests/Wolfgang.Etl.Json.Tests.Integration/Wolfgang.Etl.Json.Tests.Integration.csproj" />
   </Folder>
 </Solution>
 

--- a/tests/Wolfgang.Etl.Json.Tests.Integration/EncodingIntegrationTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Integration/EncodingIntegrationTests.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Json.Tests.Integration.TestModels;
+using Xunit;
+
+namespace Wolfgang.Etl.Json.Tests.Integration;
+
+/// <summary>
+/// Encoding-focused integration tests: non-ASCII content must survive a UTF-8
+/// round-trip, and a file carrying a leading UTF-8 byte-order mark must still
+/// extract cleanly.
+/// </summary>
+public class EncodingIntegrationTests
+{
+    private static readonly List<Person> UnicodePeople = new()
+    {
+        new Person { Id = 1, FirstName = "José", LastName = "Ångström", Age = 41 },
+        new Person { Id = 2, FirstName = "测试", LastName = "用户", Age = 33 },
+        new Person { Id = 3, FirstName = "Renée", LastName = "Müller", Age = 29 },
+    };
+
+
+
+    [Fact]
+    public async Task JsonSingleStream_when_items_contain_non_ascii_text_round_trips_unchanged()
+    {
+        using var workspace = new TempWorkspace();
+
+        using (var write = workspace.CreateFile("unicode.json"))
+        {
+            var loader = new JsonSingleStreamLoader<Person>(write);
+            await loader.LoadAsync(UnicodePeople.ToAsyncEnumerable());
+        }
+
+        var result = new List<Person>();
+        using (var read = workspace.OpenFile("unicode.json"))
+        {
+            var extractor = new JsonSingleStreamExtractor<Person>(read);
+            await foreach (var person in extractor.ExtractAsync())
+            {
+                result.Add(person);
+            }
+        }
+
+        Assert.Equal
+        (
+            UnicodePeople,
+            result
+        );
+    }
+
+
+
+    [Fact]
+    public async Task JsonLine_when_file_has_a_utf8_bom_extracts_all_items()
+    {
+        using var workspace = new TempWorkspace();
+        var path = workspace.PathFor("bom.jsonl");
+
+        // Write a JSONL file that begins with a UTF-8 BOM, then two records.
+        var bom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+        var content =
+            "{\"Id\":1,\"FirstName\":\"Alice\",\"LastName\":\"Smith\",\"Age\":30}\n" +
+            "{\"Id\":2,\"FirstName\":\"Bob\",\"LastName\":\"Jones\",\"Age\":25}\n";
+#if NET5_0_OR_GREATER
+        await File.WriteAllTextAsync(path, content, bom);
+#else
+        var preamble = bom.GetPreamble();
+        var body = new UTF8Encoding(false).GetBytes(content);
+        using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, useAsync: true))
+        {
+            await fs.WriteAsync(preamble, 0, preamble.Length);
+            await fs.WriteAsync(body, 0, body.Length);
+        }
+#endif
+
+        var result = new List<Person>();
+        using (var read = workspace.OpenFile("bom.jsonl"))
+        {
+            var extractor = new JsonLineExtractor<Person>(read);
+            await foreach (var person in extractor.ExtractAsync())
+            {
+                result.Add(person);
+            }
+        }
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Alice", result[0].FirstName);
+    }
+}

--- a/tests/Wolfgang.Etl.Json.Tests.Integration/MultiStreamRoundTripIntegrationTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Integration/MultiStreamRoundTripIntegrationTests.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Json.Tests.Integration.TestModels;
+using Xunit;
+
+namespace Wolfgang.Etl.Json.Tests.Integration;
+
+/// <summary>
+/// Round-trip tests for the multi-stream pair: the loader writes one file per
+/// item (stream chosen by item content), the extractor reads one item back per
+/// file. Order is not guaranteed across files, so comparisons are by content.
+/// </summary>
+public class MultiStreamRoundTripIntegrationTests
+{
+    private static List<Person> MakePeople(int count) =>
+        Enumerable
+            .Range(0, count)
+            .Select
+            (
+                i => new Person
+                {
+                    Id = i,
+                    FirstName = "First" + i,
+                    LastName = "Last" + i,
+                    Age = 20 + i,
+                }
+            )
+            .ToList();
+
+
+
+    [Fact]
+    public async Task JsonMultiStream_when_round_tripped_one_file_per_item_preserves_all_items()
+    {
+        using var workspace = new TempWorkspace();
+        var source = MakePeople(5);
+
+        var loader = new JsonMultiStreamLoader<Person>
+        (
+            person => workspace.CreateFile($"person-{person.Id}.json")
+        );
+        await loader.LoadAsync(source.ToAsyncEnumerable());
+
+        var files = Directory.GetFiles(workspace.Root, "person-*.json");
+        var streams = files.Select(path => File.OpenRead(path));
+
+        var result = new List<Person>();
+        var extractor = new JsonMultiStreamExtractor<Person>(streams);
+        await foreach (var person in extractor.ExtractAsync())
+        {
+            result.Add(person);
+        }
+
+        Assert.Equal
+        (
+            source.OrderBy(p => p.Id).ToList(),
+            result.OrderBy(p => p.Id).ToList()
+        );
+    }
+
+
+
+    [Fact]
+    public async Task JsonMultiStreamLoader_when_loading_writes_exactly_one_file_per_item()
+    {
+        using var workspace = new TempWorkspace();
+        var source = MakePeople(4);
+
+        var loader = new JsonMultiStreamLoader<Person>
+        (
+            person => workspace.CreateFile($"person-{person.Id}.json")
+        );
+        await loader.LoadAsync(source.ToAsyncEnumerable());
+
+        var fileCount = Directory.GetFiles(workspace.Root, "person-*.json").Length;
+
+        Assert.Equal
+        (
+            source.Count,
+            fileCount
+        );
+    }
+}

--- a/tests/Wolfgang.Etl.Json.Tests.Integration/RoundTripIntegrationTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Integration/RoundTripIntegrationTests.cs
@@ -1,0 +1,173 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Json.Tests.Integration.TestModels;
+using Xunit;
+
+namespace Wolfgang.Etl.Json.Tests.Integration;
+
+/// <summary>
+/// End-to-end round-trip tests: load items to a real file with a loader, then
+/// extract them back from that file with the matching extractor, and assert the
+/// sequence survives the trip unchanged. Exercises real <c>FileStream</c> I/O
+/// and real <c>System.Text.Json</c> serialization — not in-memory doubles.
+/// </summary>
+public class RoundTripIntegrationTests
+{
+    private static List<Person> MakePeople(int count)
+    {
+        var people = new List<Person>(count);
+        for (var i = 0; i < count; i++)
+        {
+            people.Add
+            (
+                new Person
+                {
+                    Id = i,
+                    FirstName = "First" + i,
+                    LastName = "Last" + i,
+                    Age = 20 + (i % 50),
+                }
+            );
+        }
+
+        return people;
+    }
+
+
+
+    [Fact]
+    public async Task JsonSingleStream_when_round_tripped_through_a_file_preserves_all_items_in_order()
+    {
+        using var workspace = new TempWorkspace();
+        var source = MakePeople(5);
+
+        using (var write = workspace.CreateFile("people.json"))
+        {
+            var loader = new JsonSingleStreamLoader<Person>(write);
+            await loader.LoadAsync(source.ToAsyncEnumerable());
+        }
+
+        var result = new List<Person>();
+        using (var read = workspace.OpenFile("people.json"))
+        {
+            var extractor = new JsonSingleStreamExtractor<Person>(read);
+            await foreach (var person in extractor.ExtractAsync())
+            {
+                result.Add(person);
+            }
+        }
+
+        Assert.Equal
+        (
+            source,
+            result
+        );
+    }
+
+
+
+    [Fact]
+    public async Task JsonLine_when_round_tripped_through_a_file_preserves_all_items_in_order()
+    {
+        using var workspace = new TempWorkspace();
+        var source = MakePeople(5);
+
+        using (var write = workspace.CreateFile("people.jsonl"))
+        {
+            var loader = new JsonLineLoader<Person>(write);
+            await loader.LoadAsync(source.ToAsyncEnumerable());
+        }
+
+        var result = new List<Person>();
+        using (var read = workspace.OpenFile("people.jsonl"))
+        {
+            var extractor = new JsonLineExtractor<Person>(read);
+            await foreach (var person in extractor.ExtractAsync())
+            {
+                result.Add(person);
+            }
+        }
+
+        Assert.Equal
+        (
+            source,
+            result
+        );
+    }
+
+
+
+    [Fact]
+    public async Task JsonLine_when_file_has_one_object_per_line_is_genuine_jsonl()
+    {
+        using var workspace = new TempWorkspace();
+        var source = MakePeople(3);
+
+        using (var write = workspace.CreateFile("people.jsonl"))
+        {
+            var loader = new JsonLineLoader<Person>(write);
+            await loader.LoadAsync(source.ToAsyncEnumerable());
+        }
+
+        var lines = await ReadAllNonBlankLinesAsync(workspace.PathFor("people.jsonl"));
+
+        Assert.Equal
+        (
+            source.Count,
+            lines.Count
+        );
+    }
+
+
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(10_000)]
+    public async Task JsonSingleStream_when_round_tripped_at_various_sizes_preserves_count(int count)
+    {
+        using var workspace = new TempWorkspace();
+        var source = MakePeople(count);
+
+        using (var write = workspace.CreateFile("bulk.json"))
+        {
+            var loader = new JsonSingleStreamLoader<Person>(write);
+            await loader.LoadAsync(source.ToAsyncEnumerable());
+        }
+
+        var result = new List<Person>();
+        using (var read = workspace.OpenFile("bulk.json"))
+        {
+            var extractor = new JsonSingleStreamExtractor<Person>(read);
+            await foreach (var person in extractor.ExtractAsync())
+            {
+                result.Add(person);
+            }
+        }
+
+        Assert.Equal
+        (
+            source,
+            result
+        );
+    }
+
+
+
+    private static async Task<List<string>> ReadAllNonBlankLinesAsync(string path)
+    {
+        var lines = new List<string>();
+        using var reader = new System.IO.StreamReader(path);
+        string? line;
+        while ((line = await reader.ReadLineAsync()) is not null)
+        {
+            if (!string.IsNullOrWhiteSpace(line))
+            {
+                lines.Add(line);
+            }
+        }
+
+        return lines;
+    }
+}

--- a/tests/Wolfgang.Etl.Json.Tests.Integration/SourceGenerationRoundTripIntegrationTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Integration/SourceGenerationRoundTripIntegrationTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Json.Tests.Integration.TestModels;
+using Xunit;
+
+namespace Wolfgang.Etl.Json.Tests.Integration;
+
+/// <summary>
+/// Round-trip tests that drive the source-generated <c>JsonTypeInfo&lt;T&gt;</c>
+/// (reflection-free / AOT-friendly) constructors end-to-end against real files.
+/// </summary>
+public class SourceGenerationRoundTripIntegrationTests
+{
+    private static readonly List<Person> Source = new()
+    {
+        new Person { Id = 1, FirstName = "Alice", LastName = "Smith", Age = 30 },
+        new Person { Id = 2, FirstName = "Bob", LastName = "Jones", Age = 25 },
+        new Person { Id = 3, FirstName = "Carol", LastName = "White", Age = 35 },
+    };
+
+
+
+    [Fact]
+    public async Task JsonSingleStream_when_using_source_generated_metadata_round_trips()
+    {
+        using var workspace = new TempWorkspace();
+
+        using (var write = workspace.CreateFile("sg.json"))
+        {
+            var loader = new JsonSingleStreamLoader<Person>(write, PersonJsonContext.Default.Person);
+            await loader.LoadAsync(Source.ToAsyncEnumerable());
+        }
+
+        var result = new List<Person>();
+        using (var read = workspace.OpenFile("sg.json"))
+        {
+            var extractor = new JsonSingleStreamExtractor<Person>(read, PersonJsonContext.Default.Person);
+            await foreach (var person in extractor.ExtractAsync())
+            {
+                result.Add(person);
+            }
+        }
+
+        Assert.Equal
+        (
+            Source,
+            result
+        );
+    }
+
+
+
+    [Fact]
+    public async Task JsonLine_when_using_source_generated_metadata_round_trips()
+    {
+        using var workspace = new TempWorkspace();
+
+        using (var write = workspace.CreateFile("sg.jsonl"))
+        {
+            var loader = new JsonLineLoader<Person>(write, PersonJsonContext.Default.Person);
+            await loader.LoadAsync(Source.ToAsyncEnumerable());
+        }
+
+        var result = new List<Person>();
+        using (var read = workspace.OpenFile("sg.jsonl"))
+        {
+            var extractor = new JsonLineExtractor<Person>(read, PersonJsonContext.Default.Person);
+            await foreach (var person in extractor.ExtractAsync())
+            {
+                result.Add(person);
+            }
+        }
+
+        Assert.Equal
+        (
+            Source,
+            result
+        );
+    }
+}

--- a/tests/Wolfgang.Etl.Json.Tests.Integration/TempWorkspace.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Integration/TempWorkspace.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+
+namespace Wolfgang.Etl.Json.Tests.Integration;
+
+/// <summary>
+/// Creates a unique temporary directory for a test and deletes it (recursively)
+/// on dispose. Integration tests use this to exercise the extractors and loaders
+/// against real files on disk rather than in-memory streams.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class TempWorkspace : IDisposable
+{
+    public TempWorkspace()
+    {
+        Root = Path.Combine
+        (
+            Path.GetTempPath(),
+            "Wolfgang.Etl.Json.IT." + Guid.NewGuid().ToString("N")
+        );
+        Directory.CreateDirectory(Root);
+    }
+
+
+
+    /// <summary>
+    /// Gets the absolute path of the temporary directory backing this workspace.
+    /// </summary>
+    public string Root { get; }
+
+
+
+    /// <summary>
+    /// Returns an absolute path inside the workspace for the given file name.
+    /// </summary>
+    /// <param name="fileName">The file name to combine with the workspace root.</param>
+    public string PathFor(string fileName) => Path.Combine(Root, fileName);
+
+
+
+    /// <summary>
+    /// Opens an asynchronous <see cref="FileStream"/> for writing a new file in
+    /// the workspace, overwriting any existing file of the same name.
+    /// </summary>
+    /// <param name="fileName">The file name to create.</param>
+    public FileStream CreateFile(string fileName) =>
+        new
+        (
+            PathFor(fileName),
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 4096,
+            useAsync: true
+        );
+
+
+
+    /// <summary>
+    /// Opens an asynchronous <see cref="FileStream"/> for reading an existing
+    /// file in the workspace.
+    /// </summary>
+    /// <param name="fileName">The file name to open.</param>
+    public FileStream OpenFile(string fileName) =>
+        new
+        (
+            PathFor(fileName),
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 4096,
+            useAsync: true
+        );
+
+
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(Root))
+            {
+                Directory.Delete(Root, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup: a virus scanner or lingering handle can briefly
+            // lock a temp file on Windows. The OS reclaims %TEMP% regardless, so a
+            // failed delete must not fail an otherwise-passing test.
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.Json.Tests.Integration/TestModels/Person.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Integration/TestModels/Person.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Wolfgang.Etl.Json.Tests.Integration.TestModels;
+
+/// <summary>
+/// Round-trip model for the integration tests. A <c>record</c> so equality is
+/// structural — extracted instances compare equal to the originals they were
+/// serialized from.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record Person
+{
+    public int Id { get; set; }
+
+
+
+    public string FirstName { get; set; } = string.Empty;
+
+
+
+    public string LastName { get; set; } = string.Empty;
+
+
+
+    public int Age { get; set; }
+}

--- a/tests/Wolfgang.Etl.Json.Tests.Integration/TestModels/PersonJsonContext.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Integration/TestModels/PersonJsonContext.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Wolfgang.Etl.Json.Tests.Integration.TestModels;
+
+/// <summary>
+/// Source-generated serialization context, used to exercise the
+/// <c>JsonTypeInfo&lt;T&gt;</c> (reflection-free / AOT-friendly) constructors
+/// end-to-end against real streams.
+/// </summary>
+[JsonSerializable(typeof(Person))]
+[JsonSerializable(typeof(List<Person>))]
+internal partial class PersonJsonContext : JsonSerializerContext
+{
+}

--- a/tests/Wolfgang.Etl.Json.Tests.Integration/Wolfgang.Etl.Json.Tests.Integration.csproj
+++ b/tests/Wolfgang.Etl.Json.Tests.Integration/Wolfgang.Etl.Json.Tests.Integration.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net462;net47;net471;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Version>0.2.0</Version>
+    <IsPackable>false</IsPackable>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.Json\Wolfgang.Etl.Json.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
+    <PackageReference Include="System.Text.Json" Version="10.0.9" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" NoWarn="NU1701">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+
+</Project>


### PR DESCRIPTION
Closes #84.

Adds **`tests/Wolfgang.Etl.Json.Tests.Integration`** — end-to-end round-trip tests against **real files on disk** (a disposable `TempWorkspace` creates/cleans a unique temp dir per test), complementing the in-memory unit suite.

## Coverage
- **Round-trips**: single-stream (JSON array), JSONL, and multi-stream (one file per item) — load → extract → assert the sequence is unchanged
- **Size matrix**: 0 / 1 / 10,000 items
- **JSONL shape**: file is genuinely one object per line
- **Source generation**: the `JsonTypeInfo<T>` (reflection-free / AOT) path for single + JSONL
- **Encoding**: non-ASCII content survives a UTF-8 round-trip; a file with a leading UTF-8 BOM still extracts

## Verification
Mirrors the unit project's multi-TFM setup (net462..net10.0). Builds clean across **all 13 TFMs** (Release / warnings-as-errors); **12/12 pass on net10.0 and net48**. Registered in `ETL Json.slnx`.

Note: while editing the slnx I noticed it has **pre-existing stale file references** (`REPO-INSTRUCTIONS.md`, `.github/version-picker-template.html`, `.github/workflows/codeql.yml`) — out of scope here; flagging for a separate cleanup.