### PR TITLE
chore: fix stale references in ETL Json.slnx

### DIFF
--- a/ETL Json.slnx
+++ b/ETL Json.slnx
@@ -6,14 +6,12 @@
     <File Path="Directory.Build.props" />
     <File Path="LICENSE" />
     <File Path="README.md" />
-    <File Path="REPO-INSTRUCTIONS.md" />
   </Folder>
   <Folder Name="/.root/.github/">
     <File Path=".github/CODEOWNERS" />
     <File Path=".github/copilot-instructions.md" />
     <File Path=".github/dependabot.yml" />
     <File Path=".github/pull_request_template.md" />
-    <File Path=".github/version-picker-template.html" />
   </Folder>
   <Folder Name="/.root/.github/ISSUE_TEMPLATE/">
     <File Path=".github/ISSUE_TEMPLATE/BUG_REPORT.yaml" />
@@ -21,18 +19,18 @@
   </Folder>
   <Folder Name="/.root/.github/workflows/">
     <File Path=".github/workflows/build-all-versions.yaml" />
-    <File Path=".github/workflows/codeql.yml" />
+    <File Path=".github/workflows/benchmarks.yaml" />
+    <File Path=".github/workflows/codeql.yaml" />
     <File Path=".github/workflows/docfx.yaml" />
     <File Path=".github/workflows/pr.yaml" />
     <File Path=".github/workflows/release.yaml" />
+    <File Path=".github/workflows/stryker.yaml" />
   </Folder>
   <Folder Name="/.root/docs/">
     <File Path="docs/RELEASE-WORKFLOW-SETUP.md" />
   </Folder>
   <Folder Name="/.root/scripts/">
     <File Path="scripts/format.ps1" />
-    <File Path="scripts/Setup-BranchRuleset.ps1" />
-    <File Path="scripts/Setup-GitHubPages.ps1" />
     <File Path="scripts/Setup-Labels.ps1" />
   </Folder>
   <Folder Name="/benchmarks/">


### PR DESCRIPTION
Follow-up from the #79 review (Phase 1.7 — ".slnx references real files only").

The solution pointed at files that no longer exist on main:
- `REPO-INSTRUCTIONS.md` (removed post-setup, #159)
- `.github/version-picker-template.html` (deleted in the inline-docfx work)
- `.github/workflows/codeql.yml` (renamed → `codeql.yaml`)
- `scripts/Setup-BranchRuleset.ps1`, `scripts/Setup-GitHubPages.ps1` (removed)

Fixed the codeql rename and added the two real workflows the solution was missing (`benchmarks.yaml`, `stryker.yaml`). Every `<File>`/`<Project>` reference now resolves to a file on disk.

Touches different slnx regions than #168, so the two merge cleanly in any order.