### PR TITLE
docs: standardize README heading style (#86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ This library uses `BannedSymbols.txt` to prohibit synchronous APIs:
 
 ---
 
-## Building from Source
+## 🛠️ Building from Source
 
 ### Prerequisites
 - [.NET 10.0 SDK](https://dotnet.microsoft.com/download) or later


### PR DESCRIPTION
Closes #86.

The README's section set and ordering already match the canonical layout (Installation → Features → Quick Start → Target Frameworks → Code Quality → Building → Contributing → License → Documentation). The only deviation from the repo's own convention was that **`## Building from Source` lacked the emoji prefix** that every other `##` heading carries — added `🛠️` to make all section headings consistent (and consistent with the sibling ETL repos).