### PR TITLE
chore: bump Abstractions to 0.14.1 and TestKit/Xunit to 0.9.0

### DIFF
--- a/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
+++ b/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.13.1" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.14.1" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageReference Include="System.Text.Json" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/Wolfgang.Etl.Json.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/Wolfgang.Etl.Json.Tests.Unit.csproj
@@ -22,8 +22,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="System.Text.Json" Version="10.0.9" />
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.8.1" />
-    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.8.1" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.9.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" NoWarn="NU1701">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Bumps to the latest published packages.

- `Wolfgang.Etl.Abstractions` 0.13.1 → **0.14.1** (src)
- `Wolfgang.Etl.TestKit` / `.Xunit` 0.8.1 → **0.9.0** (tests)

Clean bump — no dispose-pattern changes or `Report` property collisions (this repo was already on the 0.13.1 baseline). `Microsoft.Bcl.AsyncInterfaces` already at 10.0.9.

Verified locally: **352/352** unit tests pass; multi-TFM Release build clean.

> Note: no `vNext` branch exists in this repo, so this targets `main` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)