### PR TITLE
ci(release): add concurrency group so duplicate releases don't race

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,13 @@ permissions:
 env:
   CODECOV_MINIMUM: 90
 
+concurrency:
+  # Serialize releases so a duplicate / re-published Release event can't run two
+  # publish pipelines against NuGet and gh-pages at once. Never cancel an
+  # in-flight release — a half-published package family is worse than a queued one.
+  group: release-${{ github.event.release.tag_name || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # Streamlined validation: All frameworks, Windows only
   validate-release:


### PR DESCRIPTION
## Summary

Adds a top-level `concurrency:` group to `release.yaml` so a duplicate or re-published `release: published` event can't run two publish pipelines against NuGet and gh-pages at once. `cancel-in-progress: false` — never cancel an in-flight release.

Canonical fix from Chris-Wolfgang/repo-template#424, fanned out to the fleet. `release.yaml` is a protected file, so this needs a maintainer admin-bypass merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)