### PR TITLE
chore: fix CHANGELOG v0.1.0 link (extra dot)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,5 +74,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.2.1...HEAD
 [0.2.1]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v.0.1.0...v0.2.0
-[0.1.0]: https://github.com/Chris-Wolfgang/ETL-Json/releases/tag/v.0.1.0
+[0.2.0]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/Chris-Wolfgang/ETL-Json/releases/tag/v0.1.0

--- a/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
@@ -4,7 +4,6 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading;
-using System.Threading.Tasks;
 using System.IO;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading;
+using System.Threading.Tasks;
 using System.IO;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;


### PR DESCRIPTION
Small cleanup surfaced by Copilot's review of the June review-catchup PR (#183).

## Change

**`CHANGELOG.md`** — fix `v.0.1.0` → `v0.1.0` in the two compare/tag reference-links at the bottom. The extra dot produces broken GitHub tag/compare URLs.

## Note

The original PR also removed `using System.Threading.Tasks;` from `JsonSingleStreamExtractor.cs` on Copilot's recommendation, but CI caught that the using is actually needed on `netstandard2.0` (`WithCancellation` lives in that namespace via `Microsoft.Bcl.AsyncInterfaces`). That change has been reverted; only the CHANGELOG fix remains.