### PR TITLE
chore: bump Wolfgang.Etl.Abstractions 0.14.1 -> 0.15.0 (toward #178)

### DIFF
--- a/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
+++ b/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.14.1" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.15.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageReference Include="System.Text.Json" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />


### PR DESCRIPTION
Small package bump toward #178.

## Change

`src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj` — `Wolfgang.Etl.Abstractions` 0.14.1 → 0.15.0.

## Not in scope for this PR

Issue #178 tracks the full `ISupportDryRun` implementation on `JsonLineLoader<T>`, `JsonMultiStreamLoader<T>`, and `JsonSingleStreamLoader<T>` — that requires adding the property, gating write sites, adding `SupportsDryRunContractTests<T>`-derived tests, updating `PublicAPI.Unshipped.txt`, bumping the package version (additive surface = MINOR), and updating CHANGELOG. This PR is JUST the package reference bump so the interface becomes available for a follow-up implementation PR.

## Risk

Should be no-op for existing consumers — 0.15.0 adds `ISupportDryRun` interface but base classes deliberately don't implement it (per #178 background), so nothing in this repo's existing loader classes should light up as a breaking change. CI Stage 1/2/3 will confirm.