### PR TITLE
docfx: SHA-pin actions/checkout + actions/setup-dotnet (match repo convention)

### DIFF
--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0  # Full history needed to enumerate all v* tags
           persist-credentials: false
@@ -127,7 +127,7 @@ jobs:
           }
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: |
             5.0.x


### PR DESCRIPTION
Small fix — surfaced by Copilot's review of #183 (June review-catchup).

## Problem

`docfx.yaml` had two bare tag pins (`actions/checkout@v7` at line 63 and `actions/setup-dotnet@v5` at line 130) that drifted from the rest of the repo. Every other workflow in this repo (`pr.yaml`, `release.yaml`, `benchmarks.yaml`, `build-all-versions.yaml`, `codeql.yaml`, `stryker.yaml`) SHA-pins actions/* with the tag as a trailing comment. `CHANGELOG.md` explicitly promises this: *"SHA-pinned all GitHub-owned Actions to commit hashes."*

## Change

Reuses the same SHAs already in use by the other workflows in this repo:

- `actions/checkout@v7` → `actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7`
- `actions/setup-dotnet@v5` → `actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5`

Now every workflow in this repo is consistently SHA-pinned. Dependabot's github-actions ecosystem (added recently) will keep these fresh going forward.