### PR TITLE
feat: add Encoding property to JsonLineExtractor and JsonLineLoader (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - unreleased
+
+### Added
+
+- `JsonLineExtractor<TRecord>.Encoding` and `JsonLineLoader<TRecord>.Encoding` settable properties
+  (`System.Text.Encoding?`) that control the character encoding used when reading or writing the
+  JSONL stream. When `null` (the default), existing behavior is preserved: the extractor infers
+  encoding from the stream's BOM (falling back to UTF-8) and the loader writes UTF-8. Closes #12.
+
 ## [0.2.1] - 2026-06-26
 
 > Library public API is unchanged from `0.2.0`. This release is canonical

--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -45,6 +45,15 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
 
 
     /// <summary>
+    /// Gets or sets the character encoding to use when reading the JSONL stream.
+    /// When <see langword="null"/> (the default), the encoding is inferred from the
+    /// stream's byte-order mark (BOM), falling back to UTF-8.
+    /// </summary>
+    public System.Text.Encoding? Encoding { get; set; }
+
+
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="JsonLineExtractor{TRecord}"/> class.
     /// </summary>
     /// <param name="stream">The stream containing JSONL data to read from.</param>
@@ -181,6 +190,21 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
 
 
 
+    private StreamReader CreateStreamReader()
+    {
+#if NETSTANDARD2_0 || NET462 || NET481
+        return Encoding is null
+            ? new StreamReader(_stream, System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true)
+            : new StreamReader(_stream, Encoding, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
+#else
+        return Encoding is null
+            ? new StreamReader(_stream, leaveOpen: true)
+            : new StreamReader(_stream, Encoding, detectEncodingFromByteOrderMarks: false, bufferSize: -1, leaveOpen: true);
+#endif
+    }
+
+
+
     /// <inheritdoc />
     protected override async IAsyncEnumerable<TRecord> ExtractWorkerAsync
     (
@@ -191,11 +215,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
 
         var skipBudget = SkipItemCount;
 
-#if NETSTANDARD2_0 || NET462 || NET481
-        using var reader = new StreamReader(_stream, System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
-#else
-        using var reader = new StreamReader(_stream, leaveOpen: true);
-#endif
+        using var reader = CreateStreamReader();
 
         string? line;
 #if NETSTANDARD2_0 || NET462 || NET481

--- a/src/Wolfgang.Etl.Json/JsonLineLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineLoader.cs
@@ -42,6 +42,14 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>
 
 
     /// <summary>
+    /// Gets or sets the character encoding to use when writing the JSONL stream.
+    /// When <see langword="null"/> (the default), UTF-8 without a byte-order mark (BOM) is used.
+    /// </summary>
+    public System.Text.Encoding? Encoding { get; set; }
+
+
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="JsonLineLoader{TRecord}"/> class.
     /// </summary>
     /// <param name="stream">The stream to write JSONL data to.</param>
@@ -188,9 +196,13 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>
         JsonLogMessages.StartingOperation(_logger, OperationName, null);
 
 #if NETSTANDARD2_0 || NET462 || NET481
-        using var writer = new StreamWriter(_stream, System.Text.Encoding.UTF8, bufferSize: 1024, leaveOpen: true);
+        using var writer = Encoding is null
+            ? new StreamWriter(_stream, System.Text.Encoding.UTF8, bufferSize: 1024, leaveOpen: true)
+            : new StreamWriter(_stream, Encoding, bufferSize: 1024, leaveOpen: true);
 #else
-        using var writer = new StreamWriter(_stream, leaveOpen: true);
+        using var writer = Encoding is null
+            ? new StreamWriter(_stream, leaveOpen: true)
+            : new StreamWriter(_stream, Encoding, bufferSize: 1024, leaveOpen: true);
 #endif
 
         await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))

--- a/src/Wolfgang.Etl.Json/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.Json/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+Wolfgang.Etl.Json.JsonLineExtractor<TRecord>.Encoding.get -> System.Text.Encoding?
+Wolfgang.Etl.Json.JsonLineExtractor<TRecord>.Encoding.set -> void
+Wolfgang.Etl.Json.JsonLineLoader<TRecord>.Encoding.get -> System.Text.Encoding?
+Wolfgang.Etl.Json.JsonLineLoader<TRecord>.Encoding.set -> void

--- a/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
+++ b/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonLineExtractorTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonLineExtractorTests.cs
@@ -486,4 +486,33 @@ public class JsonLineExtractorTests
             await enumerator.DisposeAsync();
         }
     }
+
+
+
+    [Fact]
+    public void Encoding_defaults_to_null()
+    {
+        var sut = new JsonLineExtractor<PersonRecord>(new MemoryStream());
+        Assert.Null(sut.Encoding);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_Encoding_is_set_reads_stream_with_that_encoding()
+    {
+        var item = ExpectedItems[0];
+        var json = JsonSerializer.Serialize(item);
+        var content = json + "\n";
+        var stream = new MemoryStream(Encoding.GetEncoding("iso-8859-1").GetBytes(content));
+
+        var sut = new JsonLineExtractor<PersonRecord>(stream)
+        {
+            Encoding = Encoding.GetEncoding("iso-8859-1"),
+        };
+
+        var results = await sut.ExtractAsync().ToListAsync();
+
+        Assert.Equal(item, results[0]);
+    }
 }

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonLineLoaderTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonLineLoaderTests.cs
@@ -471,4 +471,37 @@ public class JsonLineLoaderTests
             )
         );
     }
+
+
+
+    [Fact]
+    public void Encoding_defaults_to_null()
+    {
+        var sut = new JsonLineLoader<PersonRecord>(new MemoryStream());
+        Assert.Null(sut.Encoding);
+    }
+
+
+
+    [Fact]
+    public async Task LoadAsync_when_Encoding_is_set_writes_stream_with_that_encoding()
+    {
+        var stream = new MemoryStream();
+        var sut = new JsonLineLoader<PersonRecord>(stream)
+        {
+            Encoding = Encoding.GetEncoding("iso-8859-1"),
+        };
+
+        var items = new List<PersonRecord>
+        {
+            new() { FirstName = "Alice", LastName = "Smith", Age = 30 },
+        };
+
+        await sut.LoadAsync(items.ToAsyncEnumerable());
+
+        stream.Position = 0;
+        using var reader = new StreamReader(stream, Encoding.GetEncoding("iso-8859-1"));
+        var content = await reader.ReadToEndAsync();
+        Assert.Contains("Alice", content);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `System.Text.Encoding? Encoding { get; set; }` to `JsonLineExtractor<TRecord>` and `JsonLineLoader<TRecord>`
- When `null` (default), existing behavior is preserved
- Extracts a `CreateStreamReader()` helper to keep `ExtractWorkerAsync` within the MA0051 60-line limit
- Version bumped to **0.3.0** (additive public API surface)

## Test plan
- [x] `Encoding_defaults_to_null` — property initializes to null on both types
- [x] `ExtractAsync_when_Encoding_is_set_reads_stream_with_that_encoding` — round-trip with ISO-8859-1
- [x] `LoadAsync_when_Encoding_is_set_writes_stream_with_that_encoding` — round-trip with ISO-8859-1
- [x] Full build passes (Release, all TFMs)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)