### PR TITLE
feat: implement ISupportDryRun on all three loaders (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - unreleased
+
+### Added
+
+- `ISupportDryRun` implemented on `JsonLineLoader<TRecord>`, `JsonSingleStreamLoader<TRecord>`,
+  and `JsonMultiStreamLoader<TRecord>`. When `IsDryRun` is `true`, the loader runs the full
+  pipeline (enumeration, `SkipItemCount`/`MaximumItemCount`, progress counters, logging) but
+  skips all writes to output stream(s). `JsonMultiStreamLoader` additionally skips calling the
+  stream factory. Closes #178.
+
 ## [0.2.1] - 2026-06-26
 
 > Library public API is unchanged from `0.2.0`. This release is canonical

--- a/src/Wolfgang.Etl.Json/JsonLineLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineLoader.cs
@@ -27,7 +27,7 @@ namespace Wolfgang.Etl.Json;
 /// await loader.LoadAsync(items, cancellationToken);
 /// </code>
 /// </example>
-public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>
+public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>, ISupportDryRun
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSONL loading of {typeof(TRecord).Name}";
@@ -38,6 +38,15 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>
     private readonly IProgressTimer? _progressTimer;
     private int _progressTimerWired;
     private long _currentLineNumber;
+
+
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// When <see langword="true"/>, the loader enumerates the source and increments
+    /// progress counters as usual but does not write any JSON to the output stream.
+    /// </remarks>
+    public bool IsDryRun { get; set; }
 
 
 
@@ -210,14 +219,18 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>
                 break;
             }
 
-            var json = _typeInfo is not null
-                ? JsonSerializer.Serialize(item, _typeInfo)
-                : JsonSerializer.Serialize(item, _options);
             Interlocked.Increment(ref _currentLineNumber);
 
+            if (!IsDryRun)
+            {
+                var json = _typeInfo is not null
+                    ? JsonSerializer.Serialize(item, _typeInfo)
+                    : JsonSerializer.Serialize(item, _options);
+
 #pragma warning disable CA1849, S6966, VSTHRD103, AsyncFixer02 // Sync WriteLine avoids async state machine allocation per item
-            writer.WriteLine(json);
+                writer.WriteLine(json);
 #pragma warning restore CA1849, S6966, VSTHRD103, AsyncFixer02
+            }
 
             IncrementCurrentItemCount();
             JsonLogMessages.LoadedItemAtLine(_logger, CurrentItemCount, Interlocked.Read(ref _currentLineNumber), null);

--- a/src/Wolfgang.Etl.Json/JsonMultiStreamLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonMultiStreamLoader.cs
@@ -32,7 +32,7 @@ namespace Wolfgang.Etl.Json;
 /// await loader.LoadAsync(items, cancellationToken);
 /// </code>
 /// </example>
-public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonReport>
+public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonReport>, ISupportDryRun
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSON multi-stream loading of {typeof(TRecord).Name}";
@@ -42,6 +42,16 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
     private readonly ILogger _logger;
     private readonly IProgressTimer? _progressTimer;
     private int _progressTimerWired;
+
+
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// When <see langword="true"/>, the loader enumerates the source and increments
+    /// progress counters as usual but skips calling the stream factory and writing
+    /// any JSON to output streams.
+    /// </remarks>
+    public bool IsDryRun { get; set; }
 
 
 
@@ -226,38 +236,53 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
                 break;
             }
 
-            var stream = _streamFactory(item);
-            if (stream is null)
+            if (IsDryRun)
             {
-                JsonLogMessages.StreamFactoryReturnedNull(_logger, streamIndex, null);
-                throw new InvalidOperationException($"Stream factory returned null for item at index {streamIndex}.");
-            }
-
-            try
-            {
-                await SerializeToStreamAsync(stream, item, token).ConfigureAwait(false);
-#if NETSTANDARD2_0 || NET462 || NET481
-#pragma warning disable CA2016, MA0040 // FlushAsync(CancellationToken) not available on this TFM
-                await stream.FlushAsync().ConfigureAwait(false);
-#pragma warning restore CA2016, MA0040
-#else
-                await stream.FlushAsync(token).ConfigureAwait(false);
-#endif
                 IncrementCurrentItemCount();
                 streamIndex++;
                 JsonLogMessages.LoadedItemToStream(_logger, CurrentItemCount, streamIndex - 1, null);
+                continue;
             }
-            finally
-            {
-#if NETSTANDARD2_0 || NET462 || NET481
-                stream.Dispose();
-#else
-                await stream.DisposeAsync().ConfigureAwait(false);
-#endif
-            }
+
+            await WriteItemToStreamAsync(item, streamIndex, token).ConfigureAwait(false);
+            IncrementCurrentItemCount();
+            streamIndex++;
+            JsonLogMessages.LoadedItemToStream(_logger, CurrentItemCount, streamIndex - 1, null);
         }
 
         JsonLogMessages.MultiStreamLoadingCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, streamIndex, null);
+    }
+
+
+
+    private async Task WriteItemToStreamAsync(TRecord item, int streamIndex, CancellationToken token)
+    {
+        var stream = _streamFactory(item);
+        if (stream is null)
+        {
+            JsonLogMessages.StreamFactoryReturnedNull(_logger, streamIndex, null);
+            throw new InvalidOperationException($"Stream factory returned null for item at index {streamIndex}.");
+        }
+
+        try
+        {
+            await SerializeToStreamAsync(stream, item, token).ConfigureAwait(false);
+#if NETSTANDARD2_0 || NET462 || NET481
+#pragma warning disable CA2016, MA0040 // FlushAsync(CancellationToken) not available on this TFM
+            await stream.FlushAsync().ConfigureAwait(false);
+#pragma warning restore CA2016, MA0040
+#else
+            await stream.FlushAsync(token).ConfigureAwait(false);
+#endif
+        }
+        finally
+        {
+#if NETSTANDARD2_0 || NET462 || NET481
+            stream.Dispose();
+#else
+            await stream.DisposeAsync().ConfigureAwait(false);
+#endif
+        }
     }
 
 

--- a/src/Wolfgang.Etl.Json/JsonSingleStreamLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonSingleStreamLoader.cs
@@ -26,7 +26,7 @@ namespace Wolfgang.Etl.Json;
 /// await loader.LoadAsync(items, cancellationToken);
 /// </code>
 /// </example>
-public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonReport>
+public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonReport>, ISupportDryRun
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSON single-stream loading of {typeof(TRecord).Name}";
@@ -36,6 +36,15 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
     private readonly ILogger _logger;
     private readonly IProgressTimer? _progressTimer;
     private int _progressTimerWired;
+
+
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// When <see langword="true"/>, the loader enumerates the source and increments
+    /// progress counters as usual but does not write any JSON to the output stream.
+    /// </remarks>
+    public bool IsDryRun { get; set; }
 
 
 
@@ -187,10 +196,10 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
 
         // CA2007/MA0004: await using declarations do not support ConfigureAwait in C#
 #pragma warning disable CA2007, MA0004
-        await using var writer = new Utf8JsonWriter(_stream);
+        await using var writer = IsDryRun ? null : new Utf8JsonWriter(_stream);
 #pragma warning restore CA2007, MA0004
 
-        writer.WriteStartArray();
+        writer?.WriteStartArray();
 
         await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
         {
@@ -209,21 +218,27 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
                 break;
             }
 
-            if (_typeInfo is not null)
+            if (writer is not null)
             {
-                JsonSerializer.Serialize(writer, item, _typeInfo);
+                if (_typeInfo is not null)
+                {
+                    JsonSerializer.Serialize(writer, item, _typeInfo);
+                }
+                else
+                {
+                    JsonSerializer.Serialize(writer, item, _options);
+                }
             }
-            else
-            {
-                JsonSerializer.Serialize(writer, item, _options);
-            }
-            IncrementCurrentItemCount();
 
+            IncrementCurrentItemCount();
             JsonLogMessages.LoadedItem(_logger, CurrentItemCount, null);
         }
 
-        writer.WriteEndArray();
-        await writer.FlushAsync(token).ConfigureAwait(false);
+        writer?.WriteEndArray();
+        if (writer is not null)
+        {
+            await writer.FlushAsync(token).ConfigureAwait(false);
+        }
 
         JsonLogMessages.SingleStreamLoadingCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, null);
     }

--- a/src/Wolfgang.Etl.Json/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.Json/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+Wolfgang.Etl.Json.JsonLineLoader<TRecord>.IsDryRun.get -> bool
+Wolfgang.Etl.Json.JsonLineLoader<TRecord>.IsDryRun.set -> void
+Wolfgang.Etl.Json.JsonMultiStreamLoader<TRecord>.IsDryRun.get -> bool
+Wolfgang.Etl.Json.JsonMultiStreamLoader<TRecord>.IsDryRun.set -> void
+Wolfgang.Etl.Json.JsonSingleStreamLoader<TRecord>.IsDryRun.get -> bool
+Wolfgang.Etl.Json.JsonSingleStreamLoader<TRecord>.IsDryRun.set -> void

--- a/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
+++ b/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonLineLoaderDryRunContractTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonLineLoaderDryRunContractTests.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Json.Tests.Unit.TestModels;
+using Wolfgang.Etl.TestKit.Xunit;
+
+namespace Wolfgang.Etl.Json.Tests.Unit;
+
+public class JsonLineLoaderDryRunContractTests
+    : SupportsDryRunContractTests<JsonLineLoader<PersonRecord>>
+{
+    private static readonly IReadOnlyList<PersonRecord> SourceItems = new List<PersonRecord>
+    {
+        new() { FirstName = "Alice", LastName = "Smith", Age = 30 },
+        new() { FirstName = "Bob", LastName = "Jones", Age = 25 },
+    };
+
+
+
+    protected override JsonLineLoader<PersonRecord> CreateSut() =>
+        new(new MemoryStream());
+
+
+
+    protected override async Task<bool> RunAndReportSideEffectAsync(bool isDryRun)
+    {
+        var stream = new MemoryStream();
+        var sut = new JsonLineLoader<PersonRecord>(stream) { IsDryRun = isDryRun };
+        await sut.LoadAsync(SourceItems.ToAsyncEnumerable());
+        return stream.Length > 0;
+    }
+}

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMultiStreamLoaderDryRunContractTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMultiStreamLoaderDryRunContractTests.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Json.Tests.Unit.TestModels;
+using Wolfgang.Etl.TestKit.Xunit;
+
+namespace Wolfgang.Etl.Json.Tests.Unit;
+
+public class JsonMultiStreamLoaderDryRunContractTests
+    : SupportsDryRunContractTests<JsonMultiStreamLoader<PersonRecord>>
+{
+    private static readonly IReadOnlyList<PersonRecord> SourceItems = new List<PersonRecord>
+    {
+        new() { FirstName = "Alice", LastName = "Smith", Age = 30 },
+        new() { FirstName = "Bob", LastName = "Jones", Age = 25 },
+    };
+
+
+
+    protected override JsonMultiStreamLoader<PersonRecord> CreateSut() =>
+        new(_ => new MemoryStream());
+
+
+
+    protected override async Task<bool> RunAndReportSideEffectAsync(bool isDryRun)
+    {
+        var factoryCalled = false;
+        var sut = new JsonMultiStreamLoader<PersonRecord>(_ =>
+        {
+            factoryCalled = true;
+            return new MemoryStream();
+        })
+        {
+            IsDryRun = isDryRun,
+        };
+
+        await sut.LoadAsync(SourceItems.ToAsyncEnumerable());
+        return factoryCalled;
+    }
+}

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonSingleStreamLoaderDryRunContractTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonSingleStreamLoaderDryRunContractTests.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Json.Tests.Unit.TestModels;
+using Wolfgang.Etl.TestKit.Xunit;
+
+namespace Wolfgang.Etl.Json.Tests.Unit;
+
+public class JsonSingleStreamLoaderDryRunContractTests
+    : SupportsDryRunContractTests<JsonSingleStreamLoader<PersonRecord>>
+{
+    private static readonly IReadOnlyList<PersonRecord> SourceItems = new List<PersonRecord>
+    {
+        new() { FirstName = "Alice", LastName = "Smith", Age = 30 },
+        new() { FirstName = "Bob", LastName = "Jones", Age = 25 },
+    };
+
+
+
+    protected override JsonSingleStreamLoader<PersonRecord> CreateSut() =>
+        new(new MemoryStream());
+
+
+
+    protected override async Task<bool> RunAndReportSideEffectAsync(bool isDryRun)
+    {
+        var stream = new MemoryStream();
+        var sut = new JsonSingleStreamLoader<PersonRecord>(stream) { IsDryRun = isDryRun };
+        await sut.LoadAsync(SourceItems.ToAsyncEnumerable());
+        return stream.Length > 0;
+    }
+}


### PR DESCRIPTION
## Summary

- `JsonLineLoader<TRecord>`, `JsonSingleStreamLoader<TRecord>`, `JsonMultiStreamLoader<TRecord>` now implement `ISupportDryRun`
- When `IsDryRun = true`: enumeration, skip/max counting, progress counters and logging all run as normal; JSON writes are skipped
- `JsonMultiStreamLoader` also skips the stream factory call (avoids creating output files/streams as a side effect)
- Extracted `WriteItemToStreamAsync` helper to stay within MA0051's 60-line limit
- Version bumped to **0.3.0** (additive public API surface; Abstractions 0.15.0 already on vNext)

## Test plan
- [x] `SupportsDryRunContractTests<JsonLineLoader>` — 5 contract tests pass
- [x] `SupportsDryRunContractTests<JsonSingleStreamLoader>` — 5 contract tests pass
- [x] `SupportsDryRunContractTests<JsonMultiStreamLoader>` — 5 contract tests pass (factory not called in dry run)
- [x] Full build passes (Release, all TFMs)

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)