### PR TITLE
feat: add integration test project and CI job (#185)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1341,6 +1341,74 @@ jobs:
           echo "PR is ready to merge! 🎉"
 
   # ============================================================================
+  # Integration Tests (Runs after Linux core tests on net8.0 and net10.0)
+  # ============================================================================
+  integration-tests:
+    name: "Integration Tests (Linux)"
+    runs-on: ubuntu-latest
+    needs: [detect-projects, test-linux-core]
+    if: github.repository != 'Chris-Wolfgang/repo-template'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        with:
+          dotnet-version: |
+            8.x
+            10.x
+
+      - name: Find and run integration test projects
+        run: |
+          integration_projects=()
+          while IFS= read -r -d '' file; do
+            integration_projects+=("$file")
+          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -name "*.Tests.Integration.*" -print0)
+
+          if [ ${#integration_projects[@]} -eq 0 ]; then
+            echo "ℹ️  No integration test projects found — skipping."
+            exit 0
+          fi
+
+          echo "=========================================="
+          echo "Found integration test projects:"
+          echo "=========================================="
+          printf '%s\n' "${integration_projects[@]}"
+          echo ""
+
+          for test_proj in "${integration_projects[@]}"; do
+            echo "=========================================="
+            echo "Testing project: $test_proj"
+            echo "=========================================="
+
+            for tfm in net8.0 net10.0; do
+              echo "--- Framework: $tfm ---"
+              dotnet test "$test_proj" \
+                --framework "$tfm" \
+                --configuration Release \
+                --logger "trx;LogFileName=integration-${tfm}.trx" \
+                --results-directory "TestResults/Integration"
+            done
+          done
+
+          echo ""
+          echo "=========================================="
+          echo "✅ INTEGRATION TESTS PASSED"
+          echo "=========================================="
+
+      - name: Upload integration test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: integration-test-results
+          path: TestResults/Integration/
+
+  # ============================================================================
   # Security Scan (Runs in parallel, independently of .NET jobs)
   # ============================================================================
   security-scan:


### PR DESCRIPTION
## Summary

- Adds `Wolfgang.Etl.Json.Tests.Integration` project with 12 tests covering real `FileStream` round-trips for `JsonSingleStreamLoader/Extractor`, `JsonLineLoader/Extractor`, `JsonMultiStreamLoader/Extractor`, encoding scenarios, and source-generation (AOT) paths
- Adds `integration-tests` job to `pr.yaml` that runs on Linux after `test-linux-core`, targeting `net8.0` and `net10.0`
- Integration projects are excluded from the existing unit test jobs via `-not -name "*.Tests.Integration.*"` (already in place)

## Test plan
- [x] 12 integration tests pass locally on net8.0
- [x] Build succeeds across net462, net481, netstandard2.0, net8.0, net10.0
- [ ] CI `integration-tests` job passes on push

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)