### PR TITLE
feat: add JsonNamedStream/JsonNamedDestination named-source overloads (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - unreleased
+
+### Added
+
+- `JsonNamedStream` record: pairs a `Stream` with an optional name for use with `JsonMultiStreamExtractor`.
+- `JsonNamedDestination` record: pairs a `Stream` with an optional name for use with `JsonMultiStreamLoader`.
+- `JsonMultiStreamExtractor<TRecord>` now accepts `IEnumerable<JsonNamedStream>` sources; the current source name surfaces in `JsonReport.CurrentSourceName` during progress reporting.
+- `JsonMultiStreamLoader<TRecord>` now accepts `Func<TRecord, JsonNamedDestination>` factory; the current destination name surfaces in `JsonReport.CurrentSourceName` during progress reporting.
+- `JsonReport.CurrentSourceName` property: the name of the stream currently being processed (`null` when not supplied or for non-multi-stream operations).
+- `JsonReport(int, int, string?)` constructor overload exposing `currentSourceName`.
+
 ## [0.2.1] - 2026-06-26
 
 > Library public API is unchanged from `0.2.0`. This release is canonical

--- a/src/Wolfgang.Etl.Json/JsonLogMessages.cs
+++ b/src/Wolfgang.Etl.Json/JsonLogMessages.cs
@@ -64,7 +64,7 @@ internal static class JsonLogMessages
     // ── MultiStream Loader ───────────────────────────────────────────
 
     internal static readonly Action<ILogger, int, Exception?> StreamFactoryReturnedNull =
-        LoggerMessage.Define<int>(LogLevel.Error, new EventId(210, nameof(StreamFactoryReturnedNull)), "Stream factory returned null for item at index {StreamIndex}.");
+        LoggerMessage.Define<int>(LogLevel.Error, new EventId(210, nameof(StreamFactoryReturnedNull)), "Factory returned null or a null stream for item at index {StreamIndex}.");
 
     internal static readonly Action<ILogger, int, int, Exception?> LoadedItemToStream =
         LoggerMessage.Define<int, int>(LogLevel.Debug, new EventId(211, nameof(LoadedItemToStream)), "Loaded item {CurrentItemCount} to stream {StreamIndex}.");

--- a/src/Wolfgang.Etl.Json/JsonMultiStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonMultiStreamExtractor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
@@ -17,15 +18,17 @@ namespace Wolfgang.Etl.Json;
 /// </summary>
 /// <typeparam name="TRecord">The type of items to extract. Must be <c>notnull</c>.</typeparam>
 /// <remarks>
-/// Iterates over an <see cref="IEnumerable{T}"/> of <see cref="Stream"/> instances,
-/// deserializing a single <typeparamref name="TRecord"/> from each stream.
+/// Iterates over an enumerable of streams, deserializing a single <typeparamref name="TRecord"/> from each.
 /// Each stream is disposed after the item is read.
 /// Extraction stops when the enumerable is exhausted or <see cref="ExtractorBase{TSource, TProgress}.MaximumItemCount"/> is reached.
+/// Supply <see cref="JsonNamedStream"/> sources to surface the current source name in progress reports
+/// via <see cref="JsonReport.CurrentSourceName"/>.
 /// </remarks>
 /// <example>
 /// <code>
-/// var streams = Directory.GetFiles("data/", "*.json").Select(File.OpenRead);
-/// var extractor = new JsonMultiStreamExtractor&lt;Person&gt;(streams, logger);
+/// var sources = Directory.GetFiles("data/", "*.json")
+///     .Select(path => new JsonNamedStream(File.OpenRead(path), path));
+/// var extractor = new JsonMultiStreamExtractor&lt;Person&gt;(sources, logger);
 /// await foreach (var person in extractor.ExtractAsync(cancellationToken))
 /// {
 ///     Console.WriteLine(person.Name);
@@ -36,12 +39,13 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSON multi-stream extraction of {typeof(TRecord).Name}";
-    private readonly IEnumerable<Stream> _streams;
+    private readonly IEnumerable<JsonNamedStream> _sources;
     private readonly JsonSerializerOptions? _options;
     private readonly JsonTypeInfo<TRecord>? _typeInfo;
     private readonly ILogger _logger;
     private readonly IProgressTimer? _progressTimer;
     private int _progressTimerWired;
+    private volatile string? _currentSourceName;
 
 
 
@@ -57,7 +61,34 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
         IEnumerable<Stream> streams
     )
     {
-        _streams = streams ?? throw new ArgumentNullException(nameof(streams));
+        if (streams is null)
+        {
+            throw new ArgumentNullException(nameof(streams));
+        }
+
+        _sources = streams.Select(s => new JsonNamedStream(s));
+        _logger = NullLogger.Instance;
+        _options = null;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonMultiStreamExtractor{TRecord}"/> class
+    /// with named sources for progress reporting.
+    /// </summary>
+    /// <param name="sources">
+    /// An enumerable of <see cref="JsonNamedStream"/> instances, each containing a stream and an optional name.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="sources"/> is <c>null</c>.
+    /// </exception>
+    public JsonMultiStreamExtractor
+    (
+        IEnumerable<JsonNamedStream> sources
+    )
+    {
+        _sources = sources ?? throw new ArgumentNullException(nameof(sources));
         _logger = NullLogger.Instance;
         _options = null;
     }
@@ -79,7 +110,36 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
         ILogger<JsonMultiStreamExtractor<TRecord>> logger
     )
     {
-        _streams = streams ?? throw new ArgumentNullException(nameof(streams));
+        if (streams is null)
+        {
+            throw new ArgumentNullException(nameof(streams));
+        }
+
+        _sources = streams.Select(s => new JsonNamedStream(s));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _options = null;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonMultiStreamExtractor{TRecord}"/> class
+    /// with named sources and diagnostic logging.
+    /// </summary>
+    /// <param name="sources">
+    /// An enumerable of <see cref="JsonNamedStream"/> instances, each containing a stream and an optional name.
+    /// </param>
+    /// <param name="logger">The logger instance for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="sources"/> or <paramref name="logger"/> is <c>null</c>.
+    /// </exception>
+    public JsonMultiStreamExtractor
+    (
+        IEnumerable<JsonNamedStream> sources,
+        ILogger<JsonMultiStreamExtractor<TRecord>> logger
+    )
+    {
+        _sources = sources ?? throw new ArgumentNullException(nameof(sources));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _options = null;
     }
@@ -103,7 +163,38 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
         ILogger<JsonMultiStreamExtractor<TRecord>>? logger = null
     )
     {
-        _streams = streams ?? throw new ArgumentNullException(nameof(streams));
+        if (streams is null)
+        {
+            throw new ArgumentNullException(nameof(streams));
+        }
+
+        _sources = streams.Select(s => new JsonNamedStream(s));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? (ILogger)NullLogger.Instance;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonMultiStreamExtractor{TRecord}"/> class
+    /// with named sources and custom serialization options.
+    /// </summary>
+    /// <param name="sources">
+    /// An enumerable of <see cref="JsonNamedStream"/> instances, each containing a stream and an optional name.
+    /// </param>
+    /// <param name="options">The JSON serializer options to use for deserialization.</param>
+    /// <param name="logger">An optional logger instance for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="sources"/> or <paramref name="options"/> is <c>null</c>.
+    /// </exception>
+    public JsonMultiStreamExtractor
+    (
+        IEnumerable<JsonNamedStream> sources,
+        JsonSerializerOptions options,
+        ILogger<JsonMultiStreamExtractor<TRecord>>? logger = null
+    )
+    {
+        _sources = sources ?? throw new ArgumentNullException(nameof(sources));
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? (ILogger)NullLogger.Instance;
     }
@@ -126,7 +217,36 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
         IProgressTimer timer
     )
     {
-        _streams = streams ?? throw new ArgumentNullException(nameof(streams));
+        if (streams is null)
+        {
+            throw new ArgumentNullException(nameof(streams));
+        }
+
+        _sources = streams.Select(s => new JsonNamedStream(s));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? (ILogger)NullLogger.Instance;
+        _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonMultiStreamExtractor{TRecord}"/> class
+    /// with named sources and an injected progress timer for testing.
+    /// </summary>
+    /// <param name="sources">An enumerable of <see cref="JsonNamedStream"/> instances.</param>
+    /// <param name="options">The JSON serializer options to use for deserialization.</param>
+    /// <param name="logger">An optional logger instance for diagnostic output.</param>
+    /// <param name="timer">The progress timer to inject.</param>
+    internal JsonMultiStreamExtractor
+    (
+        IEnumerable<JsonNamedStream> sources,
+        JsonSerializerOptions options,
+        ILogger? logger,
+        IProgressTimer timer
+    )
+    {
+        _sources = sources ?? throw new ArgumentNullException(nameof(sources));
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? (ILogger)NullLogger.Instance;
         _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
@@ -151,7 +271,38 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
         ILogger<JsonMultiStreamExtractor<TRecord>>? logger = null
     )
     {
-        _streams = streams ?? throw new ArgumentNullException(nameof(streams));
+        if (streams is null)
+        {
+            throw new ArgumentNullException(nameof(streams));
+        }
+
+        _sources = streams.Select(s => new JsonNamedStream(s));
+        _typeInfo = typeInfo ?? throw new ArgumentNullException(nameof(typeInfo));
+        _logger = logger ?? (ILogger)NullLogger.Instance;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonMultiStreamExtractor{TRecord}"/> class
+    /// with named sources and source-generated type metadata for AOT-friendly deserialization.
+    /// </summary>
+    /// <param name="sources">
+    /// An enumerable of <see cref="JsonNamedStream"/> instances, each containing a stream and an optional name.
+    /// </param>
+    /// <param name="typeInfo">The source-generated type metadata for <typeparamref name="TRecord"/>.</param>
+    /// <param name="logger">An optional logger instance for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="sources"/> or <paramref name="typeInfo"/> is <c>null</c>.
+    /// </exception>
+    public JsonMultiStreamExtractor
+    (
+        IEnumerable<JsonNamedStream> sources,
+        JsonTypeInfo<TRecord> typeInfo,
+        ILogger<JsonMultiStreamExtractor<TRecord>>? logger = null
+    )
+    {
+        _sources = sources ?? throw new ArgumentNullException(nameof(sources));
         _typeInfo = typeInfo ?? throw new ArgumentNullException(nameof(typeInfo));
         _logger = logger ?? (ILogger)NullLogger.Instance;
     }
@@ -174,7 +325,12 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
         IProgressTimer timer
     )
     {
-        _streams = streams ?? throw new ArgumentNullException(nameof(streams));
+        if (streams is null)
+        {
+            throw new ArgumentNullException(nameof(streams));
+        }
+
+        _sources = streams.Select(s => new JsonNamedStream(s));
         _typeInfo = typeInfo ?? throw new ArgumentNullException(nameof(typeInfo));
         _logger = logger ?? (ILogger)NullLogger.Instance;
         _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
@@ -193,24 +349,25 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
         var skipBudget = SkipItemCount;
         var streamIndex = 0;
 
-        foreach (var stream in _streams)
+        foreach (var source in _sources)
         {
             token.ThrowIfCancellationRequested();
+            _currentSourceName = source.Name;
             JsonLogMessages.ReadingStream(_logger, streamIndex, null);
 
             TRecord? item;
             try
             {
                 item = _typeInfo is not null
-                    ? await JsonSerializer.DeserializeAsync(stream, _typeInfo, token).ConfigureAwait(false)
-                    : await JsonSerializer.DeserializeAsync<TRecord>(stream, _options, token).ConfigureAwait(false);
+                    ? await JsonSerializer.DeserializeAsync(source.Stream, _typeInfo, token).ConfigureAwait(false)
+                    : await JsonSerializer.DeserializeAsync<TRecord>(source.Stream, _options, token).ConfigureAwait(false);
             }
             finally
             {
 #if NETSTANDARD2_0 || NET462 || NET481
-                stream.Dispose();
+                source.Stream.Dispose();
 #else
-                await stream.DisposeAsync().ConfigureAwait(false);
+                await source.Stream.DisposeAsync().ConfigureAwait(false);
 #endif
             }
 
@@ -252,7 +409,8 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
         new
         (
             CurrentItemCount,
-            CurrentSkippedItemCount
+            CurrentSkippedItemCount,
+            _currentSourceName
         );
 
 

--- a/src/Wolfgang.Etl.Json/JsonMultiStreamLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonMultiStreamLoader.cs
@@ -387,13 +387,12 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
             }
 
             var destination = _destinationFactory(item);
+            _currentDestinationName = destination?.Name;
             if (destination?.Stream is null)
             {
                 JsonLogMessages.StreamFactoryReturnedNull(_logger, streamIndex, null);
                 throw new InvalidOperationException($"Destination factory returned null or a null stream for item at index {streamIndex}.");
             }
-
-            _currentDestinationName = destination.Name;
             await WriteItemToStreamAsync(destination.Stream, item, streamIndex, token).ConfigureAwait(false);
             streamIndex++;
         }

--- a/src/Wolfgang.Etl.Json/JsonMultiStreamLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonMultiStreamLoader.cs
@@ -17,16 +17,16 @@ namespace Wolfgang.Etl.Json;
 /// </summary>
 /// <typeparam name="TRecord">The type of items to load. Must be <c>notnull</c>.</typeparam>
 /// <remarks>
-/// For each item in the input sequence, calls a factory function to obtain a <see cref="Stream"/>,
+/// For each item in the input sequence, calls a factory function to obtain a stream,
 /// serializes the item as a single JSON object, and disposes the stream.
-/// The factory receives the item being written, allowing stream creation based on item properties
-/// (e.g., generating file names from record fields).
+/// Supply a <see cref="JsonNamedDestination"/> factory to surface the current destination name
+/// in progress reports via <see cref="JsonReport.CurrentSourceName"/>.
 /// </remarks>
 /// <example>
 /// <code>
 /// var loader = new JsonMultiStreamLoader&lt;Person&gt;
 /// (
-///     person => File.Create($"output/{person.Id}.json"),
+///     person => new JsonNamedDestination(File.Create($"output/{person.Id}.json"), $"output/{person.Id}.json"),
 ///     logger
 /// );
 /// await loader.LoadAsync(items, cancellationToken);
@@ -36,12 +36,13 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSON multi-stream loading of {typeof(TRecord).Name}";
-    private readonly Func<TRecord, Stream> _streamFactory;
+    private readonly Func<TRecord, JsonNamedDestination> _destinationFactory;
     private readonly JsonSerializerOptions? _options;
     private readonly JsonTypeInfo<TRecord>? _typeInfo;
     private readonly ILogger _logger;
     private readonly IProgressTimer? _progressTimer;
     private int _progressTimerWired;
+    private volatile string? _currentDestinationName;
 
 
 
@@ -60,7 +61,35 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
         Func<TRecord, Stream> streamFactory
     )
     {
-        _streamFactory = streamFactory ?? throw new ArgumentNullException(nameof(streamFactory));
+        if (streamFactory is null)
+        {
+            throw new ArgumentNullException(nameof(streamFactory));
+        }
+
+        _destinationFactory = item => new JsonNamedDestination(streamFactory(item));
+        _logger = NullLogger.Instance;
+        _options = null;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonMultiStreamLoader{TRecord}"/> class
+    /// with a named-destination factory for progress reporting.
+    /// </summary>
+    /// <param name="destinationFactory">
+    /// A factory function that receives the item to be written and returns a <see cref="JsonNamedDestination"/>
+    /// containing the stream and an optional name. The loader will dispose the stream after writing.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="destinationFactory"/> is <c>null</c>.
+    /// </exception>
+    public JsonMultiStreamLoader
+    (
+        Func<TRecord, JsonNamedDestination> destinationFactory
+    )
+    {
+        _destinationFactory = destinationFactory ?? throw new ArgumentNullException(nameof(destinationFactory));
         _logger = NullLogger.Instance;
         _options = null;
     }
@@ -85,7 +114,37 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
         ILogger<JsonMultiStreamLoader<TRecord>> logger
     )
     {
-        _streamFactory = streamFactory ?? throw new ArgumentNullException(nameof(streamFactory));
+        if (streamFactory is null)
+        {
+            throw new ArgumentNullException(nameof(streamFactory));
+        }
+
+        _destinationFactory = item => new JsonNamedDestination(streamFactory(item));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _options = null;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonMultiStreamLoader{TRecord}"/> class
+    /// with a named-destination factory and diagnostic logging.
+    /// </summary>
+    /// <param name="destinationFactory">
+    /// A factory function that receives the item to be written and returns a <see cref="JsonNamedDestination"/>
+    /// containing the stream and an optional name. The loader will dispose the stream after writing.
+    /// </param>
+    /// <param name="logger">The logger instance for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="destinationFactory"/> or <paramref name="logger"/> is <c>null</c>.
+    /// </exception>
+    public JsonMultiStreamLoader
+    (
+        Func<TRecord, JsonNamedDestination> destinationFactory,
+        ILogger<JsonMultiStreamLoader<TRecord>> logger
+    )
+    {
+        _destinationFactory = destinationFactory ?? throw new ArgumentNullException(nameof(destinationFactory));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _options = null;
     }
@@ -112,7 +171,39 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
         ILogger<JsonMultiStreamLoader<TRecord>>? logger = null
     )
     {
-        _streamFactory = streamFactory ?? throw new ArgumentNullException(nameof(streamFactory));
+        if (streamFactory is null)
+        {
+            throw new ArgumentNullException(nameof(streamFactory));
+        }
+
+        _destinationFactory = item => new JsonNamedDestination(streamFactory(item));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? (ILogger)NullLogger.Instance;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonMultiStreamLoader{TRecord}"/> class
+    /// with a named-destination factory and custom serialization options.
+    /// </summary>
+    /// <param name="destinationFactory">
+    /// A factory function that receives the item to be written and returns a <see cref="JsonNamedDestination"/>
+    /// containing the stream and an optional name. The loader will dispose the stream after writing.
+    /// </param>
+    /// <param name="options">The JSON serializer options to use for serialization.</param>
+    /// <param name="logger">An optional logger instance for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="destinationFactory"/> or <paramref name="options"/> is <c>null</c>.
+    /// </exception>
+    public JsonMultiStreamLoader
+    (
+        Func<TRecord, JsonNamedDestination> destinationFactory,
+        JsonSerializerOptions options,
+        ILogger<JsonMultiStreamLoader<TRecord>>? logger = null
+    )
+    {
+        _destinationFactory = destinationFactory ?? throw new ArgumentNullException(nameof(destinationFactory));
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? (ILogger)NullLogger.Instance;
     }
@@ -137,7 +228,39 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
         IProgressTimer timer
     )
     {
-        _streamFactory = streamFactory ?? throw new ArgumentNullException(nameof(streamFactory));
+        if (streamFactory is null)
+        {
+            throw new ArgumentNullException(nameof(streamFactory));
+        }
+
+        _destinationFactory = item => new JsonNamedDestination(streamFactory(item));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? (ILogger)NullLogger.Instance;
+        _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonMultiStreamLoader{TRecord}"/> class
+    /// with a named-destination factory and an injected progress timer for testing.
+    /// </summary>
+    /// <param name="destinationFactory">
+    /// A factory function that returns a <see cref="JsonNamedDestination"/> for each item.
+    /// The loader will dispose the stream after writing.
+    /// </param>
+    /// <param name="options">The JSON serializer options to use for serialization.</param>
+    /// <param name="logger">An optional logger instance for diagnostic output.</param>
+    /// <param name="timer">The progress timer to inject.</param>
+    internal JsonMultiStreamLoader
+    (
+        Func<TRecord, JsonNamedDestination> destinationFactory,
+        JsonSerializerOptions options,
+        ILogger? logger,
+        IProgressTimer timer
+    )
+    {
+        _destinationFactory = destinationFactory ?? throw new ArgumentNullException(nameof(destinationFactory));
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? (ILogger)NullLogger.Instance;
         _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
@@ -165,7 +288,39 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
         ILogger<JsonMultiStreamLoader<TRecord>>? logger = null
     )
     {
-        _streamFactory = streamFactory ?? throw new ArgumentNullException(nameof(streamFactory));
+        if (streamFactory is null)
+        {
+            throw new ArgumentNullException(nameof(streamFactory));
+        }
+
+        _destinationFactory = item => new JsonNamedDestination(streamFactory(item));
+        _typeInfo = typeInfo ?? throw new ArgumentNullException(nameof(typeInfo));
+        _logger = logger ?? (ILogger)NullLogger.Instance;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonMultiStreamLoader{TRecord}"/> class
+    /// with a named-destination factory and source-generated type metadata for AOT-friendly serialization.
+    /// </summary>
+    /// <param name="destinationFactory">
+    /// A factory function that receives the item to be written and returns a <see cref="JsonNamedDestination"/>
+    /// containing the stream and an optional name. The loader will dispose the stream after writing.
+    /// </param>
+    /// <param name="typeInfo">The source-generated type metadata for <typeparamref name="TRecord"/>.</param>
+    /// <param name="logger">An optional logger instance for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="destinationFactory"/> or <paramref name="typeInfo"/> is <c>null</c>.
+    /// </exception>
+    public JsonMultiStreamLoader
+    (
+        Func<TRecord, JsonNamedDestination> destinationFactory,
+        JsonTypeInfo<TRecord> typeInfo,
+        ILogger<JsonMultiStreamLoader<TRecord>>? logger = null
+    )
+    {
+        _destinationFactory = destinationFactory ?? throw new ArgumentNullException(nameof(destinationFactory));
         _typeInfo = typeInfo ?? throw new ArgumentNullException(nameof(typeInfo));
         _logger = logger ?? (ILogger)NullLogger.Instance;
     }
@@ -190,7 +345,12 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
         IProgressTimer timer
     )
     {
-        _streamFactory = streamFactory ?? throw new ArgumentNullException(nameof(streamFactory));
+        if (streamFactory is null)
+        {
+            throw new ArgumentNullException(nameof(streamFactory));
+        }
+
+        _destinationFactory = item => new JsonNamedDestination(streamFactory(item));
         _typeInfo = typeInfo ?? throw new ArgumentNullException(nameof(typeInfo));
         _logger = logger ?? (ILogger)NullLogger.Instance;
         _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
@@ -226,38 +386,46 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
                 break;
             }
 
-            var stream = _streamFactory(item);
-            if (stream is null)
+            var destination = _destinationFactory(item);
+            if (destination?.Stream is null)
             {
                 JsonLogMessages.StreamFactoryReturnedNull(_logger, streamIndex, null);
-                throw new InvalidOperationException($"Stream factory returned null for item at index {streamIndex}.");
+                throw new InvalidOperationException($"Destination factory returned null or a null stream for item at index {streamIndex}.");
             }
 
-            try
-            {
-                await SerializeToStreamAsync(stream, item, token).ConfigureAwait(false);
-#if NETSTANDARD2_0 || NET462 || NET481
-#pragma warning disable CA2016, MA0040 // FlushAsync(CancellationToken) not available on this TFM
-                await stream.FlushAsync().ConfigureAwait(false);
-#pragma warning restore CA2016, MA0040
-#else
-                await stream.FlushAsync(token).ConfigureAwait(false);
-#endif
-                IncrementCurrentItemCount();
-                streamIndex++;
-                JsonLogMessages.LoadedItemToStream(_logger, CurrentItemCount, streamIndex - 1, null);
-            }
-            finally
-            {
-#if NETSTANDARD2_0 || NET462 || NET481
-                stream.Dispose();
-#else
-                await stream.DisposeAsync().ConfigureAwait(false);
-#endif
-            }
+            _currentDestinationName = destination.Name;
+            await WriteItemToStreamAsync(destination.Stream, item, streamIndex, token).ConfigureAwait(false);
+            streamIndex++;
         }
 
         JsonLogMessages.MultiStreamLoadingCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, streamIndex, null);
+    }
+
+
+
+    private async Task WriteItemToStreamAsync(Stream stream, TRecord item, int streamIndex, CancellationToken token)
+    {
+        try
+        {
+            await SerializeToStreamAsync(stream, item, token).ConfigureAwait(false);
+#if NETSTANDARD2_0 || NET462 || NET481
+#pragma warning disable CA2016, MA0040 // FlushAsync(CancellationToken) not available on this TFM
+            await stream.FlushAsync().ConfigureAwait(false);
+#pragma warning restore CA2016, MA0040
+#else
+            await stream.FlushAsync(token).ConfigureAwait(false);
+#endif
+            IncrementCurrentItemCount();
+            JsonLogMessages.LoadedItemToStream(_logger, CurrentItemCount, streamIndex, null);
+        }
+        finally
+        {
+#if NETSTANDARD2_0 || NET462 || NET481
+            stream.Dispose();
+#else
+            await stream.DisposeAsync().ConfigureAwait(false);
+#endif
+        }
     }
 
 
@@ -274,7 +442,8 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
         new
         (
             CurrentItemCount,
-            CurrentSkippedItemCount
+            CurrentSkippedItemCount,
+            _currentDestinationName
         );
 
 

--- a/src/Wolfgang.Etl.Json/JsonNamedDestination.cs
+++ b/src/Wolfgang.Etl.Json/JsonNamedDestination.cs
@@ -1,0 +1,13 @@
+using System.IO;
+
+namespace Wolfgang.Etl.Json;
+
+/// <summary>
+/// Associates a <see cref="Stream"/> with an optional human-readable name for progress reporting.
+/// </summary>
+/// <param name="Stream">The stream to load into.</param>
+/// <param name="Name">
+/// An optional name identifying the stream (e.g. a file path or blob key).
+/// Surfaced in <see cref="JsonReport.CurrentSourceName"/> during loading.
+/// </param>
+public sealed record JsonNamedDestination(Stream Stream, string? Name = null);

--- a/src/Wolfgang.Etl.Json/JsonNamedStream.cs
+++ b/src/Wolfgang.Etl.Json/JsonNamedStream.cs
@@ -1,0 +1,13 @@
+using System.IO;
+
+namespace Wolfgang.Etl.Json;
+
+/// <summary>
+/// Associates a <see cref="Stream"/> with an optional human-readable name for progress reporting.
+/// </summary>
+/// <param name="Stream">The stream to extract from.</param>
+/// <param name="Name">
+/// An optional name identifying the stream (e.g. a file path or blob key).
+/// Surfaced in <see cref="JsonReport.CurrentSourceName"/> during extraction.
+/// </param>
+public sealed record JsonNamedStream(Stream Stream, string? Name = null);

--- a/src/Wolfgang.Etl.Json/JsonReport.cs
+++ b/src/Wolfgang.Etl.Json/JsonReport.cs
@@ -7,7 +7,7 @@ namespace Wolfgang.Etl.Json;
 /// </summary>
 /// <remarks>
 /// Extends <see cref="Report"/> with JSON-specific progress information,
-/// including the count of skipped items.
+/// including the count of skipped items and the name of the stream currently being processed.
 /// </remarks>
 public record JsonReport : Report
 {
@@ -21,9 +21,31 @@ public record JsonReport : Report
         int currentItemCount,
         int currentSkippedItemCount
     )
+        : this(currentItemCount, currentSkippedItemCount, currentSourceName: null)
+    {
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonReport"/> class
+    /// with the name of the stream currently being processed.
+    /// </summary>
+    /// <param name="currentItemCount">The number of items processed so far.</param>
+    /// <param name="currentSkippedItemCount">The number of items skipped so far.</param>
+    /// <param name="currentSourceName">
+    /// The name of the stream currently being processed, or <c>null</c> if no name was supplied.
+    /// </param>
+    public JsonReport
+    (
+        int currentItemCount,
+        int currentSkippedItemCount,
+        string? currentSourceName
+    )
         : base(currentItemCount)
     {
         CurrentSkippedItemCount = currentSkippedItemCount;
+        CurrentSourceName = currentSourceName;
     }
 
 
@@ -32,4 +54,12 @@ public record JsonReport : Report
     /// Gets the number of items that have been skipped during processing.
     /// </summary>
     public int CurrentSkippedItemCount { get; }
+
+
+
+    /// <summary>
+    /// Gets the name of the stream currently being processed, or <c>null</c>
+    /// when the caller did not supply a name or when the operation is not multi-stream.
+    /// </summary>
+    public string? CurrentSourceName { get; }
 }

--- a/src/Wolfgang.Etl.Json/Polyfills/IsExternalInit.cs
+++ b/src/Wolfgang.Etl.Json/Polyfills/IsExternalInit.cs
@@ -1,7 +1,7 @@
 #if !NET5_0_OR_GREATER && !NETCOREAPP3_0_OR_GREATER
 namespace System.Runtime.CompilerServices;
 
-internal static class IsExternalInit
+internal class IsExternalInit
 {
 }
 #endif

--- a/src/Wolfgang.Etl.Json/Polyfills/IsExternalInit.cs
+++ b/src/Wolfgang.Etl.Json/Polyfills/IsExternalInit.cs
@@ -1,0 +1,7 @@
+#if !NET5_0_OR_GREATER && !NETCOREAPP3_0_OR_GREATER
+namespace System.Runtime.CompilerServices;
+
+internal static class IsExternalInit
+{
+}
+#endif

--- a/src/Wolfgang.Etl.Json/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.Json/PublicAPI.Unshipped.txt
@@ -1,1 +1,19 @@
 #nullable enable
+Wolfgang.Etl.Json.JsonMultiStreamExtractor<TRecord>.JsonMultiStreamExtractor(System.Collections.Generic.IEnumerable<Wolfgang.Etl.Json.JsonNamedStream> sources) -> void
+Wolfgang.Etl.Json.JsonMultiStreamExtractor<TRecord>.JsonMultiStreamExtractor(System.Collections.Generic.IEnumerable<Wolfgang.Etl.Json.JsonNamedStream> sources, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.Json.JsonMultiStreamExtractor<TRecord>> logger) -> void
+Wolfgang.Etl.Json.JsonMultiStreamExtractor<TRecord>.JsonMultiStreamExtractor(System.Collections.Generic.IEnumerable<Wolfgang.Etl.Json.JsonNamedStream> sources, System.Text.Json.JsonSerializerOptions options, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.Json.JsonMultiStreamExtractor<TRecord>> logger = null) -> void
+Wolfgang.Etl.Json.JsonMultiStreamExtractor<TRecord>.JsonMultiStreamExtractor(System.Collections.Generic.IEnumerable<Wolfgang.Etl.Json.JsonNamedStream> sources, System.Text.Json.Serialization.Metadata.JsonTypeInfo<TRecord> typeInfo, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.Json.JsonMultiStreamExtractor<TRecord>> logger = null) -> void
+Wolfgang.Etl.Json.JsonMultiStreamLoader<TRecord>.JsonMultiStreamLoader(System.Func<TRecord, Wolfgang.Etl.Json.JsonNamedDestination> destinationFactory) -> void
+Wolfgang.Etl.Json.JsonMultiStreamLoader<TRecord>.JsonMultiStreamLoader(System.Func<TRecord, Wolfgang.Etl.Json.JsonNamedDestination> destinationFactory, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.Json.JsonMultiStreamLoader<TRecord>> logger) -> void
+Wolfgang.Etl.Json.JsonMultiStreamLoader<TRecord>.JsonMultiStreamLoader(System.Func<TRecord, Wolfgang.Etl.Json.JsonNamedDestination> destinationFactory, System.Text.Json.JsonSerializerOptions options, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.Json.JsonMultiStreamLoader<TRecord>> logger = null) -> void
+Wolfgang.Etl.Json.JsonMultiStreamLoader<TRecord>.JsonMultiStreamLoader(System.Func<TRecord, Wolfgang.Etl.Json.JsonNamedDestination> destinationFactory, System.Text.Json.Serialization.Metadata.JsonTypeInfo<TRecord> typeInfo, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.Json.JsonMultiStreamLoader<TRecord>> logger = null) -> void
+Wolfgang.Etl.Json.JsonNamedDestination
+Wolfgang.Etl.Json.JsonNamedDestination.JsonNamedDestination(System.IO.Stream Stream, string Name = null) -> void
+Wolfgang.Etl.Json.JsonNamedDestination.Name.get -> string
+Wolfgang.Etl.Json.JsonNamedDestination.Stream.get -> System.IO.Stream
+Wolfgang.Etl.Json.JsonNamedStream
+Wolfgang.Etl.Json.JsonNamedStream.JsonNamedStream(System.IO.Stream Stream, string Name = null) -> void
+Wolfgang.Etl.Json.JsonNamedStream.Name.get -> string
+Wolfgang.Etl.Json.JsonNamedStream.Stream.get -> System.IO.Stream
+Wolfgang.Etl.Json.JsonReport.JsonReport(int currentItemCount, int currentSkippedItemCount, string currentSourceName) -> void
+Wolfgang.Etl.Json.JsonReport.CurrentSourceName.get -> string

--- a/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
+++ b/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMultiStreamExtractorTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMultiStreamExtractorTests.cs
@@ -140,7 +140,7 @@ public class JsonMultiStreamExtractorTests
         (
             () => new JsonMultiStreamExtractor<PersonRecord>
             (
-                null!
+                (IEnumerable<Stream>)null!
             )
         );
     }
@@ -368,7 +368,7 @@ public class JsonMultiStreamExtractorTests
         (
             () => new JsonMultiStreamExtractor<PersonRecord>
             (
-                null!,
+                (IEnumerable<Stream>)null!,
                 TestJsonContext.Default.PersonRecord,
                 NullLogger<JsonMultiStreamExtractor<PersonRecord>>.Instance
             )
@@ -471,5 +471,92 @@ public class JsonMultiStreamExtractorTests
                 timer: null!
             )
         );
+    }
+
+
+
+    [Fact]
+    public void Constructor_with_named_sources_when_sources_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new JsonMultiStreamExtractor<PersonRecord>
+            (
+                (IEnumerable<JsonNamedStream>)null!
+            )
+        );
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_named_sources_progress_report_includes_source_name()
+    {
+        var timer = new ManualProgressTimer();
+        JsonReport? capturedReport = null;
+        var progress = new SynchronousProgress<JsonReport>(r => capturedReport = r);
+
+        var item = new PersonRecord { FirstName = "Alice", LastName = "Smith", Age = 30 };
+        var stream = new MemoryStream();
+        JsonSerializer.Serialize(stream, item);
+        stream.Position = 0;
+
+        var sources = new[] { new JsonNamedStream(stream, "my-source.json") };
+        var sut = new JsonMultiStreamExtractor<PersonRecord>
+        (
+            sources,
+            new JsonSerializerOptions(),
+            logger: null,
+            timer
+        );
+
+        var enumerator = sut.ExtractAsync(progress).GetAsyncEnumerator();
+        try
+        {
+            await enumerator.MoveNextAsync();
+            timer.Fire();
+        }
+        finally
+        {
+            await enumerator.DisposeAsync();
+        }
+
+        Assert.Equal("my-source.json", capturedReport?.CurrentSourceName);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_unnamed_streams_progress_report_CurrentSourceName_is_null()
+    {
+        var timer = new ManualProgressTimer();
+        JsonReport? capturedReport = null;
+        var progress = new SynchronousProgress<JsonReport>(r => capturedReport = r);
+
+        var item = new PersonRecord { FirstName = "Alice", LastName = "Smith", Age = 30 };
+        var stream = new MemoryStream();
+        JsonSerializer.Serialize(stream, item);
+        stream.Position = 0;
+
+        var sut = new JsonMultiStreamExtractor<PersonRecord>
+        (
+            new[] { stream },
+            new JsonSerializerOptions(),
+            logger: null,
+            timer
+        );
+
+        var enumerator = sut.ExtractAsync(progress).GetAsyncEnumerator();
+        try
+        {
+            await enumerator.MoveNextAsync();
+            timer.Fire();
+        }
+        finally
+        {
+            await enumerator.DisposeAsync();
+        }
+
+        Assert.Null(capturedReport?.CurrentSourceName);
     }
 }

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMultiStreamLoaderTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMultiStreamLoaderTests.cs
@@ -133,7 +133,7 @@ public class JsonMultiStreamLoaderTests
     {
         var sut = new JsonMultiStreamLoader<PersonRecord>
         (
-            _ => null!
+            (Func<PersonRecord, Stream>)(_ => null!)
         );
 
         var items = new List<PersonRecord>
@@ -190,7 +190,7 @@ public class JsonMultiStreamLoaderTests
         (
             () => new JsonMultiStreamLoader<PersonRecord>
             (
-                null!
+                (Func<PersonRecord, Stream>)null!
             )
         );
     }
@@ -250,7 +250,7 @@ public class JsonMultiStreamLoaderTests
         (
             () => new JsonMultiStreamLoader<PersonRecord>
             (
-                null!,
+                (Func<PersonRecord, Stream>)null!,
                 new JsonSerializerOptions(),
                 NullLogger<JsonMultiStreamLoader<PersonRecord>>.Instance,
                 new ManualProgressTimer()
@@ -426,7 +426,7 @@ public class JsonMultiStreamLoaderTests
         (
             () => new JsonMultiStreamLoader<PersonRecord>
             (
-                null!,
+                (Func<PersonRecord, Stream>)null!,
                 TestJsonContext.Default.PersonRecord,
                 NullLogger<JsonMultiStreamLoader<PersonRecord>>.Instance
             )
@@ -529,5 +529,72 @@ public class JsonMultiStreamLoaderTests
                 timer: null!
             )
         );
+    }
+
+
+
+    [Fact]
+    public void Constructor_with_named_destination_factory_when_factory_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new JsonMultiStreamLoader<PersonRecord>
+            (
+                (Func<PersonRecord, JsonNamedDestination>)null!
+            )
+        );
+    }
+
+
+
+    [Fact]
+    public async Task LoadAsync_when_named_destination_factory_writes_correct_item_count()
+    {
+        var streamsCreated = 0;
+        var items = new List<PersonRecord>
+        {
+            new() { FirstName = "Alice", LastName = "Smith", Age = 30 },
+            new() { FirstName = "Bob", LastName = "Jones", Age = 25 },
+        };
+
+        var sut = new JsonMultiStreamLoader<PersonRecord>
+        (
+            _ =>
+            {
+                streamsCreated++;
+                return new JsonNamedDestination(new MemoryStream(), $"output/item-{streamsCreated}.json");
+            }
+        );
+
+        await sut.LoadAsync(items.ToAsyncEnumerable());
+
+        Assert.Equal(items.Count, sut.CurrentItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task LoadAsync_when_named_destination_factory_invokes_factory_once_per_item()
+    {
+        var namesReceived = new List<string>();
+        var items = new List<PersonRecord>
+        {
+            new() { FirstName = "Alice", LastName = "Smith", Age = 30 },
+            new() { FirstName = "Bob", LastName = "Jones", Age = 25 },
+        };
+
+        var sut = new JsonMultiStreamLoader<PersonRecord>
+        (
+            item =>
+            {
+                var name = $"output/{item.FirstName}.json";
+                namesReceived.Add(name);
+                return new JsonNamedDestination(new MemoryStream(), name);
+            }
+        );
+
+        await sut.LoadAsync(items.ToAsyncEnumerable());
+
+        Assert.Equal(new[] { "output/Alice.json", "output/Bob.json" }, namesReceived);
     }
 }

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMultiStreamLoaderTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMultiStreamLoaderTests.cs
@@ -597,4 +597,25 @@ public class JsonMultiStreamLoaderTests
 
         Assert.Equal(new[] { "output/Alice.json", "output/Bob.json" }, namesReceived);
     }
+
+
+
+    [Fact]
+    public async Task LoadAsync_when_named_destination_factory_final_progress_report_includes_destination_name()
+    {
+        var capture = new ProgressCapture<JsonReport>();
+        var items = new List<PersonRecord>
+        {
+            new() { FirstName = "Alice", LastName = "Smith", Age = 30 },
+        };
+
+        var sut = new JsonMultiStreamLoader<PersonRecord>
+        (
+            item => new JsonNamedDestination(new MemoryStream(), $"output/{item.FirstName}.json")
+        );
+
+        await sut.LoadAsync(items.ToAsyncEnumerable(), capture);
+
+        Assert.Equal("output/Alice.json", capture.FinalReport?.CurrentSourceName);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `JsonNamedStream` and `JsonNamedDestination` positional records that pair a `Stream` with an optional `Name` string (file path, blob key, URL, etc.)
- Adds named-source constructor overloads to `JsonMultiStreamExtractor<TRecord>` accepting `IEnumerable<JsonNamedStream>`
- Adds named-destination constructor overloads to `JsonMultiStreamLoader<TRecord>` accepting `Func<TRecord, JsonNamedDestination>`
- Widens `JsonReport` with a `CurrentSourceName` property (null for single-stream or unnamed callers)
- Existing `IEnumerable<Stream>` / `Func<TRecord, Stream>` constructors are fully backwards-compatible; they wrap internally and leave `CurrentSourceName` as null
- Adds `IsExternalInit` polyfill for positional record syntax on net462/netstandard2.0/net481 TFMs
- Bumps package version to 0.3.0 (new public API surface)

## Test plan
- [x] All 358 unit tests pass on net8.0
- [x] Build succeeds across net462, net481, netstandard2.0, net8.0, net10.0
- [x] Named-source extractor test verifies `CurrentSourceName` surfaces in progress via `ManualProgressTimer`
- [x] Named-destination loader tests verify factory is invoked correctly and items are counted
- [ ] CI passes

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)