### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.2.2] - 2026-07-06
+
+### Changed
+
+- Dependabot bump: dotnet-dependencies group (7 packages).
+
 ## [0.2.1] - 2026-06-26
 
 > Library public API is unchanged from `0.2.0`. This release is canonical
@@ -72,7 +90,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cached the default `JsonSerializerOptions` and log operation-name strings as
   static fields; sealed the extractor and loader classes.
 
-[Unreleased]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v.0.1.0...v0.2.0
 [0.1.0]: https://github.com/Chris-Wolfgang/ETL-Json/releases/tag/v.0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dependabot bump: dotnet-dependencies group (7 packages).
-
 ## [0.2.1] - 2026-06-26
 
 > Library public API is unchanged from `0.2.0`. This release is canonical

--- a/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
+++ b/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.2.1</Version>
+    <Version>0.2.2</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +


### PR DESCRIPTION
## Release prep — v0.2.2

Bump `<Version>` in `src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj` from `0.2.1` to `0.2.2`, promote `[Unreleased]` in CHANGELOG.md, add compare-link.

### Section

```
### Changed
- Dependabot bump: dotnet-dependencies group (7 packages).
```

## After merge

Create the release: `gh release create v0.2.2 --target main --title "v0.2.2" --generate-notes` (or via UI). The release.yaml workflow fires on `release: published` and handles the NuGet publish.