### PR TITLE
perf: throw before constructing the error object on the Throw path (addresses #198 review)

### DIFF
--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -315,12 +315,12 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
         catch (JsonException ex)
 #pragma warning restore CA1031
         {
+            if (ErrorHandling == ErrorHandling.Throw) { throw; }
             var error = new JsonDeserializationError(
                 itemIndex: _errors.Count + CurrentItemCount + CurrentSkippedItemCount,
                 lineNumber: lineNum,
                 rawContent: line,
                 exception: ex);
-            if (ErrorHandling == ErrorHandling.Throw) { throw; }
             if (ErrorHandling == ErrorHandling.CaptureAndContinue) { _errors.Add(error); }
             JsonLogMessages.DeserializationErrorAtLine(_logger, lineNum, ex);
             item = default;


### PR DESCRIPTION
## Summary

Follow-up to a review comment on the (already-merged) #198 that landed before it could be addressed.

@Chris-Wolfgang asked, on `JsonLineExtractor.TryDeserializeLine`:

> should this be moved up before the above line since if this is true error is declared but never used

Correct. On the `ErrorHandling.Throw` path the code constructed a `JsonDeserializationError` and then immediately `throw`-ed the original `JsonException` — so the freshly-allocated `error` was never used. `error` is only consumed by the `CaptureAndContinue` branch (`_errors.Add(error)`).

## Change

Move the `if (ErrorHandling == ErrorHandling.Throw) { throw; }` short-circuit **above** the `error` construction:

```diff
-            var error = new JsonDeserializationError(
-                itemIndex: _errors.Count + CurrentItemCount + CurrentSkippedItemCount,
-                lineNumber: lineNum,
-                rawContent: line,
-                exception: ex);
             if (ErrorHandling == ErrorHandling.Throw) { throw; }
+            var error = new JsonDeserializationError(
+                itemIndex: _errors.Count + CurrentItemCount + CurrentSkippedItemCount,
+                lineNumber: lineNum,
+                rawContent: line,
+                exception: ex);
             if (ErrorHandling == ErrorHandling.CaptureAndContinue) { _errors.Add(error); }
```

Now the allocation only happens when the error is actually recorded. `itemIndex` still reads the correct `_errors.Count` (the throw path never touches `_errors`).

Behavior is unchanged for all policies; this is a pure allocation-on-the-throw-path optimization. Targets `vNext`.