### PR TITLE
ci: SHA-pin docfx.yaml actions; add InspectCode job to pr.yaml

### DIFF
--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0  # Full history needed to enumerate all v* tags
           persist-credentials: false
@@ -127,7 +127,7 @@ jobs:
           }
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: |
             5.0.x

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -273,7 +273,7 @@ jobs:
       - name: Restore + Build (Release)
         run: |
           dotnet restore
-          dotnet build -c Release --no-restore
+          dotnet build src -c Release --no-restore --framework net10.0
 
       - name: Install JetBrains.ReSharper.GlobalTools
         run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
@@ -1441,9 +1441,11 @@ jobs:
       - name: Find and run integration test projects
         run: |
           integration_projects=()
-          while IFS= read -r -d '' file; do
-            integration_projects+=("$file")
-          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -name "*.Tests.Integration.*" -print0)
+          if [ -d ./tests ]; then
+            while IFS= read -r -d '' file; do
+              integration_projects+=("$file")
+            done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -name "*.Tests.Integration.*" -print0)
+          fi
 
           if [ ${#integration_projects[@]} -eq 0 ]; then
             echo "ℹ️  No integration test projects found — skipping."

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -239,6 +239,81 @@ jobs:
             echo "has-projects=false" >> "$GITHUB_OUTPUT"
             echo "ℹ️  No .NET project files found - skipping .NET build and test jobs"
           fi
+  # ============================================================================
+  # INSPECTCODE: JetBrains ReSharper InspectCode parallel to the test stages.
+  # Runs concurrently with Stage 1 / 2 / 3 (no `needs:` on a test job) so it
+  # doesn't extend wall-clock — typically 3–5 min vs the slowest stage.
+  # SARIF uploads to GitHub Code Scanning (Security tab + inline PR
+  # annotations). `error`-severity findings fail the job; `warning`-severity
+  # surfaces in Code Scanning but doesn't fail (gated by --severity=WARNING
+  # filter). Tune the noise floor via .DotSettings at the repo root.
+  # ============================================================================
+  inspectcode:
+    name: "ReSharper InspectCode"
+    runs-on: ubuntu-latest
+    needs: detect-projects
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write   # required for upload-sarif
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore + Build (Release)
+        run: |
+          dotnet restore
+          dotnet build -c Release --no-restore
+
+      - name: Install JetBrains.ReSharper.GlobalTools
+        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+
+      - name: Run InspectCode
+        run: |
+          # Find a solution to inspect. Prefer .slnx (new format) then .sln.
+          # InspectCode requires SOMETHING solution-shaped — fail loudly if neither exists.
+          SLN=$(ls *.slnx 2>/dev/null | head -n1)
+          if [ -z "$SLN" ]; then
+            SLN=$(ls *.sln 2>/dev/null | head -n1)
+          fi
+          if [ -z "$SLN" ]; then
+            echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
+            exit 1
+          fi
+          echo "Inspecting: $SLN"
+          jb inspectcode "$SLN" \
+            --output=inspect.sarif \
+            --format=sarif \
+            --severity=WARNING \
+            --no-build
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        with:
+          sarif_file: inspect.sarif
+
+      - name: Gate on error-severity findings
+        run: |
+          # SARIF level=error fails the job; warnings still upload (visible in
+          # Security → Code scanning) but don't gate merge — raise to `error`
+          # later when the noise floor is acceptable.
+          count=$(jq '[.runs[].results[] | select(.level=="error")] | length' inspect.sarif)
+          if [ "$count" -gt 0 ]; then
+            echo "::error::$count InspectCode error-severity finding(s) — see Security → Code scanning"
+            exit 1
+          fi
+          echo "✅ No error-severity InspectCode findings."
+
 
   # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
@@ -1339,6 +1414,75 @@ jobs:
           echo "Stage 3: macOS tests ✅"
           echo ""
           echo "PR is ready to merge! 🎉"
+
+  # ============================================================================
+  # Integration Tests (Runs after Linux core tests on net8.0 and net10.0)
+  # ============================================================================
+  integration-tests:
+    name: "Integration Tests (Linux)"
+    runs-on: ubuntu-latest
+    needs: [detect-projects, test-linux-core]
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        with:
+          dotnet-version: |
+            8.x
+            10.x
+
+      - name: Find and run integration test projects
+        run: |
+          integration_projects=()
+          while IFS= read -r -d '' file; do
+            integration_projects+=("$file")
+          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -name "*.Tests.Integration.*" -print0)
+
+          if [ ${#integration_projects[@]} -eq 0 ]; then
+            echo "ℹ️  No integration test projects found — skipping."
+            exit 0
+          fi
+
+          echo "=========================================="
+          echo "Found integration test projects:"
+          echo "=========================================="
+          printf '%s\n' "${integration_projects[@]}"
+          echo ""
+
+          for test_proj in "${integration_projects[@]}"; do
+            echo "=========================================="
+            echo "Testing project: $test_proj"
+            echo "=========================================="
+
+            proj_name=$(basename "$test_proj" .csproj)
+            for tfm in net8.0 net10.0; do
+              echo "--- Framework: $tfm ---"
+              dotnet test "$test_proj" \
+                --framework "$tfm" \
+                --configuration Release \
+                --logger "trx;LogFileName=${proj_name}-${tfm}.trx" \
+                --results-directory "TestResults/Integration"
+            done
+          done
+
+          echo ""
+          echo "=========================================="
+          echo "✅ INTEGRATION TESTS PASSED"
+          echo "=========================================="
+
+      - name: Upload integration test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: integration-test-results
+          path: TestResults/Integration/
 
   # ============================================================================
   # Security Scan (Runs in parallel, independently of .NET jobs)


### PR DESCRIPTION
## Summary

Workflow-only changes split out of #205 to clear the protected-file gate.

- `docfx.yaml`: SHA-pin `actions/checkout` and `actions/setup-dotnet`
- `pr.yaml`: SHA-pin the same actions + add canonical ReSharper InspectCode job + add Integration Tests job (Linux, net8+net10)

## Merge notes

Needs admin bypass (workflow files are protected). After merging, #205 (vNext→main) will no longer touch protected files and can merge normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)