### PR TITLE
build: harden build-pr.ps1 gitleaks install (macOS arch + tar-from-stdin)

### DIFF
--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -295,7 +295,18 @@ if (-not $SkipSecurity) {
             $env:PATH = "$dest;$env:PATH"
         }
         else {
-            $archive = "gitleaks_${version}_linux_x64.tar.gz"
+            # gitleaks ships separate darwin / linux builds, and on macOS we
+            # also have to pick between x64 (Intel) and arm64 (Apple Silicon).
+            # Without this branch the macOS path would download the Linux
+            # tarball and either fail to install or install an incompatible
+            # binary.
+            if ($IsMacOS) {
+                $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
+                $archive = "gitleaks_${version}_darwin_${arch}.tar.gz"
+            }
+            else {
+                $archive = "gitleaks_${version}_linux_x64.tar.gz"
+            }
             $url = "https://github.com/gitleaks/gitleaks/releases/download/v${version}/$archive"
             # Install to a user-writable location instead of /usr/local/bin
             # (which would require sudo for most local dev shells). $HOME/.local/bin

--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -300,12 +300,12 @@ if (-not $SkipSecurity) {
             # Without this branch the macOS path would download the Linux
             # tarball and either fail to install or install an incompatible
             # binary.
+            $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
             if ($IsMacOS) {
-                $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
                 $archive = "gitleaks_${version}_darwin_${arch}.tar.gz"
             }
             else {
-                $archive = "gitleaks_${version}_linux_x64.tar.gz"
+                $archive = "gitleaks_${version}_linux_${arch}.tar.gz"
             }
             $url = "https://github.com/gitleaks/gitleaks/releases/download/v${version}/$archive"
             # Install to a user-writable location instead of /usr/local/bin


### PR DESCRIPTION
Fleet-sync of two portability improvements into this repo's local `pr.yaml` mirror (`scripts/build-pr.ps1`), found during an audit of the ETL repos' local gates:

- **macOS darwin/arm64 branch** — the non-Windows gitleaks install always downloaded the Linux tarball, which fails / installs an incompatible binary on macOS (esp. Apple Silicon).
- **`tar -xz -f -`** — read the archive from stdin explicitly; GNU tar without `-f` defaults to `/dev/tape` and can hang silently in CI / fresh shells.

Brings this repo's `build-pr.ps1` in line with canonical (ETL-FixedWidth #214 / repo-template #432). Dev-tooling script only — not compiled or exercised by `pr.yaml`'s build/test/coverage gate, so no build/test surface. PowerShell hand-verified.