### PR TITLE
fix: use explicit project path in InspectCode build step

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -273,7 +273,7 @@ jobs:
       - name: Restore + Build (Release)
         run: |
           dotnet restore
-          dotnet build src -c Release --no-restore --framework net10.0
+          dotnet build src/Wolfgang.Etl.Json -c Release --no-restore --framework net10.0
 
       - name: Install JetBrains.ReSharper.GlobalTools
         run: dotnet tool install -g JetBrains.ReSharper.GlobalTools


### PR DESCRIPTION
## Summary
- `dotnet build src` fails with MSB1003 because `src/` has no `.csproj` directly in it — the project lives in `src/Wolfgang.Etl.Json/`
- All three open PRs (#207, #208, #210) were failing on the ReSharper InspectCode step because `pull_request_target` always runs pr.yaml from main
- Fix: change to `dotnet build src/Wolfgang.Etl.Json`

## Test plan
- [ ] Verify InspectCode job passes on this PR
- [ ] Re-run CI on #207, #208, #210 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)