### PR TITLE
maint: Tier-1 CI hardening (zizmor, actionlint, Scorecard, reproducible-build, Stryker)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -282,9 +282,9 @@ jobs:
         run: |
           # Find a solution to inspect. Prefer .slnx (new format) then .sln.
           # InspectCode requires SOMETHING solution-shaped — fail loudly if neither exists.
-          SLN=$(ls *.slnx 2>/dev/null | head -n1)
+          SLN=$(find . -maxdepth 1 -name '*.slnx' -print -quit)
           if [ -z "$SLN" ]; then
-            SLN=$(ls *.sln 2>/dev/null | head -n1)
+            SLN=$(find . -maxdepth 1 -name '*.sln' -print -quit)
           fi
           if [ -z "$SLN" ]; then
             echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."

--- a/.github/workflows/reproducible-build.yaml
+++ b/.github/workflows/reproducible-build.yaml
@@ -1,0 +1,82 @@
+name: Build reproducibility
+
+# Verifies that the deterministic-build knobs in Directory.Build.props
+# (<Deterministic>, <ContinuousIntegrationBuild>, SourceLink,
+# EmbedUntrackedSources) actually produce byte-identical managed assemblies
+# when the same commit is built on different runners. Advisory — cross-OS
+# differences are reported as a warning, not a hard failure.
+# Closes #133.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '40 5 * * 1'   # Mondays 05:40 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build + hash (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Build src (net8.0, Release, deterministic)
+        shell: bash
+        run: |
+          dotnet build src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj \
+            -c Release -f net8.0 -p:ContinuousIntegrationBuild=true
+
+      - name: Hash assemblies
+        shell: bash
+        run: |
+          sha256sum \
+            src/Wolfgang.Etl.Json/bin/Release/net8.0/Wolfgang.Etl.Json.dll \
+            | awk '{ n = split($2, parts, "/"); print $1 "  " parts[n] }' \
+            | sort > "hashes-${{ matrix.os }}.txt"
+          echo "== ${{ matrix.os }} =="
+          cat "hashes-${{ matrix.os }}.txt"
+
+      - name: Upload hashes
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: hashes-${{ matrix.os }}
+          path: hashes-${{ matrix.os }}.txt
+
+  compare:
+    name: Compare across runners
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download hashes
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: hashes
+
+      - name: Diff manifests
+        shell: bash
+        run: |
+          ubuntu="hashes/hashes-ubuntu-latest/hashes-ubuntu-latest.txt"
+          windows="hashes/hashes-windows-latest/hashes-windows-latest.txt"
+          echo "== ubuntu-latest =="; cat "$ubuntu"
+          echo "== windows-latest =="; cat "$windows"
+          if diff -u "$ubuntu" "$windows"; then
+            echo "✅ Reproducible: managed assembly hashes match across ubuntu + windows."
+          else
+            echo "::warning::Assembly hashes differ across runners — the build is not byte-identical cross-OS. Investigate embedded paths / SourceLink normalization."
+          fi

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,60 @@
+name: OSSF Scorecard
+
+# Runs the OpenSSF Scorecard automated security-posture audit and uploads
+# the results to the Security tab (Code scanning). Provides a public scorecard
+# badge consumers can use to evaluate this package's supply-chain posture.
+#
+# References:
+# - https://github.com/ossf/scorecard-action
+# - https://securityscorecards.dev/
+# Closes #139.
+
+on:
+  schedule:
+    # Sunday 06:00 UTC — matches stryker.yaml's weekly cadence.
+    - cron: '0 6 * * 0'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Top-level read-only default; jobs declare narrower writes where required.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write   # upload SARIF to code-scanning dashboard
+      id-token: write          # OIDC token for publishing to public Scorecard registry
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # publish_results: true uploads to the public Scorecard registry so
+          # the badge resolves on the README. Safe — only summary metrics are
+          # published, never code.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning dashboard
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -1,0 +1,89 @@
+name: Workflow Security
+
+# Lints the GitHub Actions YAML files themselves for:
+#   - syntax errors and common mistakes (actionlint)
+#   - workflow-security vulnerabilities — untrusted-input injection, missing
+#     permissions blocks, expression-context secret expansion, unpinned
+#     third-party actions (zizmor)
+#
+# Complementary to CodeQL (which scans .cs source) and to the manual
+# Actions-hardening review. Strictly additive; does not gate merge today,
+# but a high-severity new finding will surface as a PR annotation.
+# Closes #140.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.zizmor.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.zizmor.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        # Pinned to v1.7.7. Download via official script from the version tag
+        # for content-pinning — not from main — so a future change can't
+        # retroactively alter what this CI does.
+        run: |
+          curl -sSfLo /tmp/download-actionlint.bash \
+            https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash
+          bash /tmp/download-actionlint.bash 1.7.7 /tmp
+          /tmp/actionlint
+        shell: bash
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # SARIF upload to the Security tab
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12'
+
+      - name: Install zizmor
+        run: pip install --user 'zizmor==1.5.2'
+
+      - name: Run zizmor (SARIF output)
+        # --offline avoids GitHub API calls during the lint.
+        # --persona auditor enables stricter rules appropriate for a library
+        # shipping to the public NuGet feed.
+        run: |
+          zizmor --offline --persona auditor --format sarif \
+            .github/workflows/ > zizmor.sarif || true
+
+      - name: Upload SARIF to code-scanning
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        if: always()
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -1,0 +1,18 @@
+# zizmor baseline configuration.
+#
+# Suppress accepted-as-intentional findings here, with rule_id + path +
+# rationale. Empty today — accumulate suppressions as real findings are
+# reviewed and either fixed or formally accepted.
+#
+# Format: https://woodruffw.github.io/zizmor/configuration/
+#
+# Example for future reference:
+#
+# rules:
+#   dangerous-triggers:
+#     ignore:
+#       - path: .github/workflows/pr.yaml
+#         comment: |
+#           pull_request_target is intentional here so PR validation runs
+#           from main's trusted version of the workflow rather than the
+#           PR-author-controlled HEAD. See security note at top of pr.yaml.

--- a/stryker-config.json
+++ b/stryker-config.json
@@ -1,0 +1,19 @@
+{
+  "stryker-config": {
+    "project": "src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj",
+    "test-projects": [
+      "tests/Wolfgang.Etl.Json.Tests.Unit/Wolfgang.Etl.Json.Tests.Unit.csproj"
+    ],
+    "target-framework": "net10.0",
+    "reporters": [
+      "html",
+      "json",
+      "progress"
+    ],
+    "thresholds": {
+      "high": 90,
+      "low": 75,
+      "break": 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Five Tier-1 maintenance items from issue #72:

- **#140** — `workflow-security.yaml`: actionlint (v1.7.7) + zizmor (v1.5.2), SARIF → Code Scanning; triggers on PRs/pushes touching `.github/workflows/`
- **#139** — `scorecard.yaml`: OSSF Scorecard weekly scan + on-push-to-main, publishes to public API for README badge
- **#133** — `reproducible-build.yaml`: byte-identity check across ubuntu + windows runners (weekly + manual); advisory — cross-OS diffs are `::warning::` not hard failures
- **#122** — `stryker-config.json`: Stryker setup for Wolfgang.Etl.Json; the existing `stryker.yaml` auto-discovers and runs it on its weekly schedule; threshold `high=90 / low=75 / break=0`
- **#118** (already closed directly) — DevSkim already live in `pr.yaml`; no new code needed

Also adds `.zizmor.yml` baseline suppression config at repo root.

## Notes

All three new workflow files touch `.github/workflows/*.yaml` — the protected-file guard will block standard CI. **Requires admin-bypass merge.**

Actions SHA-pinned per fleet convention:
- `actions/checkout@9c091bb...` (v7)
- `actions/setup-dotnet@26b0ec14...` (v5)
- `actions/upload-artifact@043fb46d...` (v7)
- `actions/download-artifact@3e5f45b2...` (v8.0.1)
- `ossf/scorecard-action@4eaacf05...` (v2.4.3)
- `github/codeql-action/upload-sarif@99df26d4...` (v4)
- `actions/setup-python@ece7cb06...` (v6)

## Test plan

- [ ] Admin-bypass merge to main
- [ ] Scorecard job fires on push to main
- [ ] Run `workflow_dispatch` on `reproducible-build.yaml` — verify compare job passes
- [ ] Run `workflow_dispatch` on `stryker.yaml` — Stryker should pick up stryker-config.json and run

🤖 Generated with [Claude Code](https://claude.com/claude-code)