### PR TITLE
maint: add AOT/trim smoke test example and workflow

### DIFF
--- a/.github/workflows/aot-smoke.yaml
+++ b/.github/workflows/aot-smoke.yaml
@@ -1,0 +1,117 @@
+# AOT / trim publish smoke test.
+#
+# Publishes examples/Wolfgang.Etl.Json.Example.AotSmoke with
+# <PublishAot>true</PublishAot> + <PublishTrimmed>true</PublishTrimmed>
+# and runs the resulting native binary. Surfaces IL2xxx / AOT0xxx /
+# IL3xxx warnings so we know which library surfaces the trimmer /
+# AOT compiler can't see through.
+#
+# The library's JsonTypeInfo<T> overloads (used by the smoke example)
+# carry [RequiresDynamicCode] / [RequiresUnreferencedCode] guards on the
+# reflection-based overloads, so AOT-clean paths are explicitly marked.
+# This workflow verifies those paths produce a runnable binary.
+#
+# Status: INFORMATIONAL / NON-BLOCKING today (continue-on-error).
+# Refs #130.
+name: AOT + trim smoke
+
+on:
+  pull_request_target:
+    paths:
+      - "src/**"
+      - "examples/Wolfgang.Etl.Json.Example.AotSmoke/**"
+      - ".github/workflows/aot-smoke.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "examples/Wolfgang.Etl.Json.Example.AotSmoke/**"
+      - ".github/workflows/aot-smoke.yaml"
+  workflow_dispatch:
+
+jobs:
+  aot-smoke:
+    name: PublishAot + PublishTrimmed
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore examples/Wolfgang.Etl.Json.Example.AotSmoke/Wolfgang.Etl.Json.Example.AotSmoke.csproj
+
+      - name: Publish (PublishAot + PublishTrimmed)
+        id: publish
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          mkdir -p publish
+          dotnet publish \
+            examples/Wolfgang.Etl.Json.Example.AotSmoke/Wolfgang.Etl.Json.Example.AotSmoke.csproj \
+            --configuration Release \
+            --runtime linux-x64 \
+            --self-contained true \
+            --output publish \
+            -p:PublishAot=true \
+            -p:PublishTrimmed=true \
+            -p:TrimmerSingleWarn=false \
+            2>&1 | tee publish.log
+
+      - name: Summarize trim / AOT warnings
+        if: always()
+        run: |
+          echo "## AOT + trim smoke — warning summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ ! -f publish.log ]; then
+            echo "publish step produced no log — likely errored before running dotnet." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          il2_count=$(grep -c "warning IL2" publish.log || true)
+          il3_count=$(grep -c "warning IL3" publish.log || true)
+          aot_count=$(grep -c "warning AOT" publish.log || true)
+          echo "| Category | Count |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Trim (IL2xxx) | $il2_count |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Single-file (IL3xxx) | $il3_count |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| AOT (AOT0xxx) | $aot_count |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$il2_count" -gt 0 ] || [ "$il3_count" -gt 0 ] || [ "$aot_count" -gt 0 ]; then
+            echo "<details><summary>First 20 warnings</summary>" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            grep -E "warning (IL[23]|AOT)" publish.log | head -20 >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Gate mode**: non-blocking (informational). Promote to blocking once IL2xxx count reaches zero." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run the AOT-published binary
+        if: steps.publish.outcome == 'success'
+        run: |
+          bin=publish/Wolfgang.Etl.Json.Example.AotSmoke
+          if [ ! -x "$bin" ]; then
+            echo "::warning::AOT-published binary not found at $bin — publish output layout may have changed."
+            exit 0
+          fi
+          "$bin"
+
+      - name: Upload publish log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: aot-smoke-publish-log
+          path: publish.log
+          retention-days: 30

--- a/.github/workflows/aot-smoke.yaml
+++ b/.github/workflows/aot-smoke.yaml
@@ -71,32 +71,34 @@ jobs:
       - name: Summarize trim / AOT warnings
         if: always()
         run: |
-          echo "## AOT + trim smoke — warning summary" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          if [ ! -f publish.log ]; then
-            echo "publish step produced no log — likely errored before running dotnet." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          il2_count=$(grep -c "warning IL2" publish.log || true)
-          il3_count=$(grep -c "warning IL3" publish.log || true)
-          aot_count=$(grep -c "warning AOT" publish.log || true)
-          echo "| Category | Count |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Trim (IL2xxx) | $il2_count |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Single-file (IL3xxx) | $il3_count |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| AOT (AOT0xxx) | $aot_count |" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          if [ "$il2_count" -gt 0 ] || [ "$il3_count" -gt 0 ] || [ "$aot_count" -gt 0 ]; then
-            echo "<details><summary>First 20 warnings</summary>" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-            grep -E "warning (IL[23]|AOT)" publish.log | head -20 >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "</details>" >> "$GITHUB_STEP_SUMMARY"
-          fi
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Gate mode**: non-blocking (informational). Promote to blocking once IL2xxx count reaches zero." >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## AOT + trim smoke — warning summary"
+            echo ""
+            if [ ! -f publish.log ]; then
+              echo "publish step produced no log — likely errored before running dotnet."
+              exit 0
+            fi
+            il2_count=$(grep -c "warning IL2" publish.log || true)
+            il3_count=$(grep -c "warning IL3" publish.log || true)
+            aot_count=$(grep -c "warning AOT" publish.log || true)
+            echo "| Category | Count |"
+            echo "|---|---|"
+            echo "| Trim (IL2xxx) | $il2_count |"
+            echo "| Single-file (IL3xxx) | $il3_count |"
+            echo "| AOT (AOT0xxx) | $aot_count |"
+            echo ""
+            if [ "$il2_count" -gt 0 ] || [ "$il3_count" -gt 0 ] || [ "$aot_count" -gt 0 ]; then
+              echo "<details><summary>First 20 warnings</summary>"
+              echo ""
+              echo '```'
+              grep -E "warning (IL[23]|AOT)" publish.log | head -20
+              echo '```'
+              echo ""
+              echo "</details>"
+            fi
+            echo ""
+            echo "**Gate mode**: non-blocking (informational). Promote to blocking once IL2xxx count reaches zero."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run the AOT-published binary
         if: steps.publish.outcome == 'success'

--- a/ETL Json.slnx
+++ b/ETL Json.slnx
@@ -38,6 +38,7 @@
   </Folder>
   <Folder Name="/examples/">
     <Project Path="examples/Wolfgang.Etl.Json.Examples/Wolfgang.Etl.Json.Examples.csproj" />
+    <Project Path="examples/Wolfgang.Etl.Json.Example.AotSmoke/Wolfgang.Etl.Json.Example.AotSmoke.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj" />

--- a/examples/Wolfgang.Etl.Json.Example.AotSmoke/AotPerson.cs
+++ b/examples/Wolfgang.Etl.Json.Example.AotSmoke/AotPerson.cs
@@ -1,0 +1,3 @@
+namespace Wolfgang.Etl.Json.Example.AotSmoke;
+
+internal sealed record AotPerson(string FirstName, string LastName, int Age);

--- a/examples/Wolfgang.Etl.Json.Example.AotSmoke/AotPersonContext.cs
+++ b/examples/Wolfgang.Etl.Json.Example.AotSmoke/AotPersonContext.cs
@@ -1,0 +1,6 @@
+using System.Text.Json.Serialization;
+
+namespace Wolfgang.Etl.Json.Example.AotSmoke;
+
+[JsonSerializable(typeof(AotPerson))]
+internal sealed partial class AotPersonContext : JsonSerializerContext;

--- a/examples/Wolfgang.Etl.Json.Example.AotSmoke/Program.cs
+++ b/examples/Wolfgang.Etl.Json.Example.AotSmoke/Program.cs
@@ -1,0 +1,120 @@
+// AOT smoke test for Wolfgang.Etl.Json.
+// Exercises the JsonTypeInfo<T> overloads (AOT-safe) to verify the library's
+// source-generated path works under a native-AOT publish.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Json;
+using Wolfgang.Etl.Json.Example.AotSmoke;
+
+await RunSingleStreamRoundtrip();
+await RunJsonLineRoundtrip();
+await RunMultiStreamRoundtrip();
+Console.WriteLine("AOT smoke: all paths OK.");
+
+
+
+static async Task RunSingleStreamRoundtrip()
+{
+    var people = new List<AotPerson>
+    {
+        new("Alice", "Smith", 30),
+        new("Bob", "Jones", 25),
+    };
+
+    var typeInfo = AotPersonContext.Default.AotPerson;
+    var stream = new MemoryStream();
+
+    var loader = new JsonSingleStreamLoader<AotPerson>(stream, typeInfo);
+    await loader.LoadAsync(people.ToAsyncEnumerable());
+
+    stream.Position = 0;
+    var extractor = new JsonSingleStreamExtractor<AotPerson>(stream, typeInfo);
+    var extracted = await extractor.ExtractAsync().ToListAsync();
+
+    if (extracted.Count != people.Count)
+    {
+        throw new InvalidOperationException($"Single-stream: expected {people.Count} items, got {extracted.Count}");
+    }
+}
+
+
+
+static async Task RunJsonLineRoundtrip()
+{
+    var people = new List<AotPerson>
+    {
+        new("Carol", "White", 35),
+        new("Dave", "Black", 40),
+    };
+
+    var typeInfo = AotPersonContext.Default.AotPerson;
+    var stream = new MemoryStream();
+
+    var loader = new JsonLineLoader<AotPerson>(stream, typeInfo);
+    await loader.LoadAsync(people.ToAsyncEnumerable());
+
+    stream.Position = 0;
+    var extractor = new JsonLineExtractor<AotPerson>(stream, typeInfo);
+    var extracted = await extractor.ExtractAsync().ToListAsync();
+
+    if (extracted.Count != people.Count)
+    {
+        throw new InvalidOperationException($"JSONL: expected {people.Count} items, got {extracted.Count}");
+    }
+}
+
+
+
+static async Task RunMultiStreamRoundtrip()
+{
+    var people = new List<AotPerson>
+    {
+        new("Eve", "Green", 28),
+        new("Frank", "Blue", 33),
+    };
+
+    var typeInfo = AotPersonContext.Default.AotPerson;
+
+    var streams = people
+        .Select(p =>
+        {
+            var ms = new MemoryStream();
+            // Write each person to its own MemoryStream synchronously via Span
+            var bytes = System.Text.Encoding.UTF8.GetBytes(
+                System.Text.Json.JsonSerializer.Serialize(p, typeInfo));
+            ms.Write(bytes);
+            ms.Position = 0;
+            return (Stream)ms;
+        })
+        .Select((s, i) => new JsonNamedStream(s, $"person-{i}.json"))
+        .ToList();
+
+    var extractor = new JsonMultiStreamExtractor<AotPerson>(streams, typeInfo);
+    var extracted = await extractor.ExtractAsync().ToListAsync();
+
+    if (extracted.Count != people.Count)
+    {
+        throw new InvalidOperationException($"Multi-stream: expected {people.Count} items, got {extracted.Count}");
+    }
+}
+
+
+
+namespace Wolfgang.Etl.Json.Example.AotSmoke
+{
+    internal static class AsyncEnumerableExtensions
+    {
+        internal static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> source)
+        {
+            var list = new List<T>();
+            await foreach (var item in source)
+            {
+                list.Add(item);
+            }
+            return list;
+        }
+    }
+}

--- a/examples/Wolfgang.Etl.Json.Example.AotSmoke/Wolfgang.Etl.Json.Example.AotSmoke.csproj
+++ b/examples/Wolfgang.Etl.Json.Example.AotSmoke/Wolfgang.Etl.Json.Example.AotSmoke.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <!-- PublishAot is set at publish time; this flag enables ILLink warnings
+         at build time so trim/AOT issues surface during development. -->
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.Json\Wolfgang.Etl.Json.csproj" />
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+</Project>


### PR DESCRIPTION
## Summary

- Adds `examples/Wolfgang.Etl.Json.Example.AotSmoke/` — minimal console app that exercises the `JsonTypeInfo<T>` (AOT-safe) overloads: Single-stream, JSONL, and Multi-stream roundtrip (#130)
- Adds `.github/workflows/aot-smoke.yaml`: publishes with `PublishAot=true` + `PublishTrimmed=true`, runs the binary, summarizes IL2xxx/IL3xxx/AOT0xxx warning counts in the job summary
- **Non-blocking today** (`continue-on-error: true`) — promotes to blocking when the warning count reaches zero

The smoke example intentionally uses only the `JsonTypeInfo<T>` constructor overloads (AOT-safe). The reflection-based overloads carry `[RequiresDynamicCode]` / `[RequiresUnreferencedCode]` guards and are expected to produce warnings if exercised.

## Test plan

- [ ] Admin-bypass merge (touches `aot-smoke.yaml` which is a protected file)
- [ ] Run `workflow_dispatch` on `aot-smoke.yaml` — verify publish succeeds and binary runs
- [ ] Check job summary for IL2xxx/AOT0xxx warning counts

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)