### PR TITLE
maint: add license audit workflow and allowlist config

### DIFF
--- a/.github/license/allowed-licenses.json
+++ b/.github/license/allowed-licenses.json
@@ -1,0 +1,10 @@
+[
+  "MIT",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "MS-PL",
+  "0BSD",
+  "MICROSOFT-DISTRIBUTABLE-CODE",
+  "MICROSOFT-DOTNET-LIBRARY"
+]

--- a/.github/license/licenseurl-mappings.json
+++ b/.github/license/licenseurl-mappings.json
@@ -1,0 +1,6 @@
+{
+  "https://github.com/Microsoft/dotnet/blob/master/LICENSE": "MIT",
+  "https://aka.ms/deprecateLicenseUrl": "MICROSOFT-DISTRIBUTABLE-CODE",
+  "http://go.microsoft.com/fwlink/?LinkId=329770": "MICROSOFT-DOTNET-LIBRARY",
+  "https://go.microsoft.com/fwlink/?LinkId=329770": "MICROSOFT-DOTNET-LIBRARY"
+}

--- a/.github/license/packages-filter.json
+++ b/.github/license/packages-filter.json
@@ -1,0 +1,14 @@
+[
+  "AsyncFixer",
+  "Meziantou.Analyzer",
+  "SonarAnalyzer.CSharp",
+  "Roslynator.Analyzers",
+  "Microsoft.CodeAnalysis.BannedApiAnalyzers",
+  "Microsoft.CodeAnalysis.PublicApiAnalyzers",
+  "Microsoft.SourceLink.Common",
+  "Microsoft.SourceLink.GitHub",
+  "Microsoft.Build.Tasks.Git",
+  "Microsoft.VisualStudio.Threading.Analyzers",
+  "NETStandard.Library",
+  "Microsoft.NETCore.Platforms"
+]

--- a/.github/workflows/license-audit.yaml
+++ b/.github/workflows/license-audit.yaml
@@ -1,0 +1,98 @@
+name: License audit
+
+# Audits the licenses of the shipped packages' transitive dependencies against
+# an allowlist, and generates THIRD-PARTY-NOTICES.md attribution. Dev-only
+# tooling (analyzers / SourceLink / framework shims — all PrivateAssets, never
+# shipped) is filtered out via .github/license/packages-filter.json. Fails the
+# run if a runtime dependency carries a license outside the allowlist.
+
+on:
+  pull_request:
+    paths:
+      - '**/*.csproj'
+      - 'Directory.Build.props'
+      - '.github/license/**'
+      - '.github/workflows/license-audit.yaml'
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '15 6 * * 1'   # Mondays 06:15 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  license-audit:
+    name: Audit dependency licenses
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up .NET
+        # 7.0.x (EOL) is installed only because the dotnet-project-licenses tool
+        # targets net7.0; the runner image no longer ships it, so the tool fails
+        # to launch without an explicit install. Do not remove.
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: |
+            7.0.x
+            8.0.x
+            10.0.x
+
+      - name: Install dotnet-project-licenses
+        run: dotnet tool install --global dotnet-project-licenses --version 2.7.1
+
+      - name: Restore (populates project.assets.json)
+        run: dotnet restore
+
+      - name: Audit licenses + generate notices
+        shell: bash
+        run: |
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          projects=(
+            src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
+          )
+          {
+            echo "# Third-party notices"
+            echo
+            echo "Licenses of the transitive runtime dependencies of the shipped"
+            echo "\`Wolfgang.Etl.Json\` package. Dev-only tooling (analyzers,"
+            echo "SourceLink, framework shims) is excluded — it is never distributed."
+            echo
+          } > THIRD-PARTY-NOTICES.md
+
+          fail=0
+          for proj in "${projects[@]}"; do
+            name=$(basename "$proj" .csproj)
+            echo "::group::License audit — $name"
+            if ! dotnet-project-licenses \
+                --input "$proj" \
+                --use-project-assets-json -t \
+                --packages-filter .github/license/packages-filter.json \
+                --licenseurl-to-license-mappings .github/license/licenseurl-mappings.json \
+                --allowed-license-types .github/license/allowed-licenses.json \
+                --outfile "notices-$name.md" --md
+            then
+              echo "::error::Disallowed license in $name — see the log above."
+              fail=1
+            fi
+            echo "::endgroup::"
+            {
+              echo "## $name"
+              echo
+              cat "notices-$name.md" 2>/dev/null || true
+              echo
+            } >> THIRD-PARTY-NOTICES.md
+          done
+          exit $fail
+
+      - name: Upload notices
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: third-party-notices
+          path: THIRD-PARTY-NOTICES.md
+          retention-days: 30


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/license-audit.yaml` — runs `dotnet-project-licenses` on every PR touching a `.csproj` or the allowlist, on push to `main`, and weekly on Mondays.
- Adds `.github/license/` config: `allowed-licenses.json`, `licenseurl-mappings.json`, `packages-filter.json` — allowlist covers MIT/Apache-2.0/BSD/MS-PL/0BSD and the two Microsoft redistributable buckets; dev-only tooling (analyzers, SourceLink) is excluded from the audit.
- Generates `THIRD-PARTY-NOTICES.md` as a build artifact each run.

## Notes

- `license-audit.yaml` touches `.github/workflows/` → requires **admin-bypass** merge.
- The `.github/license/` config files are **not** protected — they can be updated by normal PRs if the allowlist ever needs adjustment (e.g., a new acceptable license added).
- Adapted from the canonical pattern already live in ETL-SqlBulkCopy.

## Test plan

- [ ] Push to this branch and verify the `license-audit` job passes on CI.
- [ ] Confirm the `THIRD-PARTY-NOTICES.md` artifact is uploaded and lists the expected packages.

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)