### PR TITLE
feat: per-PR BDN delta gate (pr-benchmarks.yaml)

### DIFF
--- a/.github/workflows/pr-benchmarks.yaml
+++ b/.github/workflows/pr-benchmarks.yaml
@@ -1,0 +1,219 @@
+name: PR Benchmarks
+
+# Runs BenchmarkDotNet on both the PR HEAD and the base branch tip, then posts
+# a delta table as a PR comment (replacing it on each push).  Fails the PR if
+# any benchmark regresses beyond the configured thresholds unless the PR carries
+# the perf-impact-acknowledged label.
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'benchmarks/**'
+      - '.github/workflows/pr-benchmarks.yaml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BENCH_PROJECT: benchmarks/Wolfgang.Etl.Json.Benchmarks/Wolfgang.Etl.Json.Benchmarks.csproj
+  BENCH_DIR: benchmarks/Wolfgang.Etl.Json.Benchmarks
+
+jobs:
+  benchmark-delta:
+    name: BDN delta (HEAD vs base)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: |
+            10.0.x
+
+      # ── Base run ──────────────────────────────────────────────────────────
+
+      - name: Run benchmarks on base (${{ github.event.pull_request.base.sha }})
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }}
+          dotnet restore "$BENCH_PROJECT"
+          dotnet build -c Release --no-restore "$BENCH_PROJECT"
+          cd "$BENCH_DIR"
+          dotnet run -c Release --no-build -- --filter "*" --job short --memory --exporters json
+          shopt -s nullglob
+          reports=(BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json)
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "::error::No BDN JSON produced for base run"
+            exit 1
+          fi
+          jq -s '{Title:"base",HostEnvironmentInfo:.[0].HostEnvironmentInfo,Benchmarks:[.[].Benchmarks[]]}' \
+            "${reports[@]}" > /tmp/bdn-base.json
+
+      # ── HEAD run ──────────────────────────────────────────────────────────
+
+      - name: Run benchmarks on HEAD (${{ github.event.pull_request.head.sha }})
+        run: |
+          git checkout ${{ github.event.pull_request.head.sha }}
+          rm -rf "$BENCH_DIR/BenchmarkDotNet.Artifacts"
+          dotnet restore "$BENCH_PROJECT"
+          dotnet build -c Release --no-restore "$BENCH_PROJECT"
+          cd "$BENCH_DIR"
+          dotnet run -c Release --no-build -- --filter "*" --job short --memory --exporters json
+          shopt -s nullglob
+          reports=(BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json)
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "::error::No BDN JSON produced for HEAD run"
+            exit 1
+          fi
+          jq -s '{Title:"head",HostEnvironmentInfo:.[0].HostEnvironmentInfo,Benchmarks:[.[].Benchmarks[]]}' \
+            "${reports[@]}" > /tmp/bdn-head.json
+
+      # ── Delta + comment ───────────────────────────────────────────────────
+
+      - name: Compute delta and post PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          MEAN_THRESHOLD: '20'
+          ALLOC_THRESHOLD: '50'
+          EXEMPT_LABEL: perf-impact-acknowledged
+        run: |
+          node << 'NODEJS'
+          const fs = require('fs');
+          const { execFileSync } = require('child_process');
+
+          const base = JSON.parse(fs.readFileSync('/tmp/bdn-base.json', 'utf8'));
+          const head = JSON.parse(fs.readFileSync('/tmp/bdn-head.json', 'utf8'));
+
+          const baseLookup = Object.fromEntries(
+            base.Benchmarks.map(b => [b.FullName, b])
+          );
+
+          const MEAN_THRESHOLD = parseFloat(process.env.MEAN_THRESHOLD);
+          const ALLOC_THRESHOLD = parseFloat(process.env.ALLOC_THRESHOLD);
+          const EXEMPT_LABEL = process.env.EXEMPT_LABEL;
+          const labels = JSON.parse(process.env.PR_LABELS || '[]');
+          const isExempt = labels.includes(EXEMPT_LABEL);
+
+          function fmtTime(ns) {
+            if (ns < 1000) return ns.toFixed(1) + ' ns';
+            if (ns < 1e6) return (ns / 1000).toFixed(2) + ' μs';
+            if (ns < 1e9) return (ns / 1e6).toFixed(2) + ' ms';
+            return (ns / 1e9).toFixed(3) + ' s';
+          }
+
+          function fmtBytes(b) {
+            if (b === 0 || b === null || b === undefined) return '0 B';
+            if (b < 1024) return b + ' B';
+            if (b < 1048576) return (b / 1024).toFixed(1) + ' KB';
+            return (b / 1048576).toFixed(2) + ' MB';
+          }
+
+          function fmtDelta(pct) {
+            const sign = pct > 0 ? '+' : '';
+            return sign + pct.toFixed(1) + '%';
+          }
+
+          function trafficLight(pct, threshold) {
+            if (pct > threshold) return '🔴';
+            if (pct > threshold / 2) return '🟡';
+            if (pct < -5) return '🟢';
+            return '⚪';
+          }
+
+          const rows = [];
+          let hasRegression = false;
+
+          for (const hb of head.Benchmarks) {
+            const bb = baseLookup[hb.FullName];
+            if (!bb) continue;
+
+            const headMean = hb.Statistics.Mean;
+            const baseMean = bb.Statistics.Mean;
+            const headAlloc = hb.Memory?.BytesAllocatedPerOperation ?? 0;
+            const baseAlloc = bb.Memory?.BytesAllocatedPerOperation ?? 0;
+
+            const deltaMean = baseMean > 0 ? ((headMean - baseMean) / baseMean * 100) : 0;
+            const deltaAlloc = baseAlloc > 0 ? ((headAlloc - baseAlloc) / baseAlloc * 100) : 0;
+
+            if (deltaMean > MEAN_THRESHOLD || deltaAlloc > ALLOC_THRESHOLD) {
+              hasRegression = true;
+            }
+
+            const parts = hb.FullName.split('.');
+            const shortName = parts.slice(-2).join('.');
+
+            rows.push(
+              `| ${shortName} ` +
+              `| ${fmtTime(baseMean)} | ${fmtTime(headMean)} | ${trafficLight(deltaMean, MEAN_THRESHOLD)} ${fmtDelta(deltaMean)} ` +
+              `| ${fmtBytes(baseAlloc)} | ${fmtBytes(headAlloc)} | ${trafficLight(deltaAlloc, ALLOC_THRESHOLD)} ${fmtDelta(deltaAlloc)} |`
+            );
+          }
+
+          const baseSha = process.env.BASE_SHA.slice(0, 7);
+          const headSha = process.env.HEAD_SHA.slice(0, 7);
+
+          let verdict;
+          if (hasRegression && !isExempt) {
+            verdict = `> ⚠️ **Regression detected.** At least one benchmark exceeded the threshold (>${MEAN_THRESHOLD}% mean or >${ALLOC_THRESHOLD}% alloc). Add the \`${EXEMPT_LABEL}\` label to acknowledge intentional perf impact.`;
+          } else if (hasRegression) {
+            verdict = `> ℹ️ Regression present but acknowledged via \`${EXEMPT_LABEL}\` label.`;
+          } else {
+            verdict = '> ✅ No regressions detected.';
+          }
+
+          const body = [
+            '<!-- bdn-delta -->',
+            '## BenchmarkDotNet — PR delta',
+            '',
+            `Comparing \`${baseSha}\` (base) → \`${headSha}\` (HEAD)`,
+            `Thresholds: mean >${MEAN_THRESHOLD}% = 🔴, alloc >${ALLOC_THRESHOLD}% = 🔴`,
+            '',
+            '| Benchmark | Base mean | HEAD mean | Δ mean | Base alloc | HEAD alloc | Δ alloc |',
+            '|-----------|----------:|----------:|-------:|-----------:|-----------:|--------:|',
+            ...rows,
+            '',
+            verdict,
+          ].join('\n');
+
+          fs.writeFileSync('/tmp/bdn-comment.json', JSON.stringify({ body }));
+
+          const existing = execFileSync('gh', [
+            'api', `repos/${process.env.REPO}/issues/${process.env.PR_NUMBER}/comments`,
+            '--jq', '[.[] | select(.body | startswith("<!-- bdn-delta -->"))] | first | .id // empty',
+          ], { encoding: 'utf8' }).trim();
+
+          if (existing) {
+            execFileSync('gh', [
+              'api', `repos/${process.env.REPO}/issues/comments/${existing}`,
+              '--method', 'PATCH', '--input', '/tmp/bdn-comment.json',
+            ]);
+            console.log('Updated comment', existing);
+          } else {
+            execFileSync('gh', [
+              'api', `repos/${process.env.REPO}/issues/${process.env.PR_NUMBER}/comments`,
+              '--method', 'POST', '--input', '/tmp/bdn-comment.json',
+            ]);
+            console.log('Posted new comment');
+          }
+
+          if (hasRegression && !isExempt) {
+            console.error('::error::Performance regression detected — see PR comment for details');
+            process.exit(1);
+          }
+          NODEJS


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pr-benchmarks.yaml` — runs BenchmarkDotNet on both the PR HEAD and the base branch tip
- Posts a markdown delta table as a PR comment (replaces it on each push, never appends)
- Fails the PR if any benchmark exceeds thresholds (>20% mean, >50% alloc), unless the PR carries the `perf-impact-acknowledged` label
- Only triggers on changes to `src/**`, `benchmarks/**`, or the workflow itself

## How it works

1. `git checkout <base-sha>` → build → run BDN `--job short` → capture JSON
2. `git checkout <head-sha>` → clean artifacts → build → run BDN → capture JSON
3. Node.js script computes per-benchmark deltas, formats a table (🔴/🟡/🟢/⚪ per column), finds/replaces the existing `<!-- bdn-delta -->` PR comment via `gh api`
4. Exits non-zero on regression (unless exempt label present)

## Test plan

- [ ] Open a test PR touching `src/` — confirm workflow runs and posts a comment
- [ ] Push another commit — confirm the comment is *replaced*, not a second comment
- [ ] Add `perf-impact-acknowledged` label to a regression PR — confirm it passes
- [ ] Verify workflow is skipped on PRs that touch only docs/tests

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)