### PR TITLE
ci: generate reproducible-build-manifest.json per release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -568,6 +568,25 @@ jobs:
           }
 
 
+      - name: Generate reproducible-build hash manifest
+        if: steps.check-packages.outputs.has-packages == 'true'
+        shell: pwsh
+        env:
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          $artifacts = Get-ChildItem -Path 'nuget-packages' -Include '*.nupkg','*.snupkg' -Recurse -ErrorAction SilentlyContinue
+          $entries = $artifacts | ForEach-Object {
+            $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLower()
+            [ordered]@{ name = $_.Name; sha256 = $hash }
+          }
+          $manifest = [ordered]@{
+            version   = ($env:RELEASE_TAG_NAME -replace '^v\.?', '')
+            artifacts = @($entries)
+          }
+          $manifest | ConvertTo-Json -Depth 5 |
+            Out-File -FilePath 'nuget-packages/reproducible-build-manifest.json' -Encoding utf8NoBOM
+          Write-Host "✅ Hash manifest written" -ForegroundColor Green
+
       - name: Upload NuGet packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -789,5 +808,6 @@ jobs:
             ./nuget-packages/*.nupkg
             ./nuget-packages/*.snupkg
             ./nuget-packages/*.bom.json
+            ./nuget-packages/reproducible-build-manifest.json
             release-coverage.zip
 


### PR DESCRIPTION
## Summary

- Adds a "Generate reproducible-build hash manifest" step to `pack-and-validate` in `release.yaml`
- Computes SHA-256 for every `.nupkg`/`.snupkg`, writes `reproducible-build-manifest.json`
- Manifest is uploaded with the `nuget-packages` artifact and attached to the GitHub Release assets
- Adds `./nuget-packages/reproducible-build-manifest.json` to the `softprops/action-gh-release` files list

## Manifest format

```json
{
  "version": "0.3.0",
  "artifacts": [
    { "name": "Wolfgang.Etl.Json.0.3.0.nupkg", "sha256": "..." },
    { "name": "Wolfgang.Etl.Json.0.3.0.snupkg", "sha256": "..." }
  ]
}
```

## ⚠️ Admin bypass required

This PR touches `.github/workflows/release.yaml`, which is a protected file. Requires admin bypass to merge.

Companion non-protected PR: `maint/reproducible-build-docs` (normal merge, merge that first).

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)