### PR TITLE
docs: ADR index + 3 ADRs + migration guide template

### DIFF
--- a/docs/adr/ADR-001-system-text-json.md
+++ b/docs/adr/ADR-001-system-text-json.md
@@ -1,0 +1,52 @@
+# ADR-001 System.Text.Json over Newtonsoft.Json
+
+- **Status**: Accepted
+- **Date**: 2026-07-16
+
+---
+
+## Context
+
+ETL-Json needs a JSON serialization library for its extractors and loaders. The library targets a wide TFM range: net462, netstandard2.0, netstandard2.1, net8.0, and net10.0. A choice must be made between the two dominant .NET JSON libraries. High-throughput ETL workloads make performance and allocation overhead meaningful factors.
+
+---
+
+## Decision
+
+We will use System.Text.Json for all JSON serialization and deserialization.
+
+---
+
+## Considered Options
+
+### Option A: Newtonsoft.Json
+
+- Pro: Mature, battle-tested, and widely understood.
+- Pro: Flexible — supports dynamic types, BSON, and complex contract resolvers.
+- Con: Adds a NuGet transitive dependency that all consumers inherit.
+- Con: Not AOT-compatible without significant extra configuration.
+- Con: Measurably slower and higher-allocating than System.Text.Json for high-throughput scenarios.
+
+### Option B: System.Text.Json
+
+- Pro: Available on net462+ via a NuGet polyfill; inbox on net5+ with zero extra dependency.
+- Pro: First-class AOT support via `JsonTypeInfo<T>` source-generated constructors.
+- Pro: Significantly faster and lower-allocating than Newtonsoft in benchmark comparisons.
+- Pro: No transitive dependency added to consumer projects on net5+.
+- Con: Consumers must use `[JsonPropertyName]` and related attributes instead of Newtonsoft conventions.
+- Con: No BSON or dynamic-type support — acceptable for this library's use cases.
+
+---
+
+## Consequences
+
+**Easier:**
+
+- AOT deployment scenarios are supported without additional configuration.
+- Consumer projects on net5+ gain no new transitive dependencies.
+- High-throughput workloads benefit from lower allocations and faster serialization.
+
+**Harder:**
+
+- Consumers migrating from Newtonsoft must replace `[JsonProperty]` with `[JsonPropertyName]` and similar attribute swaps.
+- Dynamic/BSON scenarios are not supported and must be handled outside this library.

--- a/docs/adr/ADR-002-sync-writeline-loader-hot-path.md
+++ b/docs/adr/ADR-002-sync-writeline-loader-hot-path.md
@@ -1,0 +1,47 @@
+# ADR-002 Sync StreamWriter.WriteLine in Loader Hot Paths
+
+- **Status**: Accepted
+- **Date**: 2026-07-16
+
+---
+
+## Context
+
+`JsonLineLoader` and `JsonMultiStreamLoader` write one serialized JSON line per item inside a tight `await foreach` loop. ETL workloads can process millions of items in a single run, so per-item allocation overhead is a meaningful concern. The choice between async and sync writes affects both allocation behavior and overall throughput.
+
+---
+
+## Decision
+
+We will use synchronous `writer.WriteLine(json)` inside async methods, suppressing `CA1849` and `AsyncFixer02` with `#pragma warning disable/restore` placed directly above the method.
+
+---
+
+## Considered Options
+
+### Option A: `await writer.WriteLineAsync(json)`
+
+- Pro: Fully async — consistent with async-all-the-way guidelines.
+- Con: Allocates an async state machine per item (typically 64–200 bytes).
+- Con: Across millions of items this produces significant GC pressure and degrades ETL throughput.
+
+### Option B: Sync `writer.WriteLine(json)` (chosen)
+
+- Pro: No per-item async state machine allocation.
+- Pro: `StreamWriter` has a large internal buffer; sync writes do not hit the OS synchronously — they are absorbed by the buffer and flushed at dispose or explicit `Flush()`.
+- Con: Requires `#pragma warning disable CA1849, AsyncFixer02` to satisfy analyzers.
+- Con: The pragmas must be placed above the method, not above `[Fact]`/`[Theory]` attributes, per project conventions.
+
+---
+
+## Consequences
+
+**Easier:**
+
+- High-throughput loads run with substantially lower GC pressure.
+- No per-item heap allocation from async state machines.
+
+**Harder:**
+
+- Two analyzer suppressions (`CA1849`, `AsyncFixer02`) are required above each affected method; these are intentional and must not be removed without revisiting the allocation trade-off.
+- Reviewers unfamiliar with this ADR may flag the suppressions; this document serves as the authoritative explanation.

--- a/docs/adr/ADR-003-leaveopen-streamwriter-compat.md
+++ b/docs/adr/ADR-003-leaveopen-streamwriter-compat.md
@@ -1,0 +1,47 @@
+# ADR-003 `#if` Guards in CreateStreamWriter for leaveOpen Compat
+
+- **Status**: Accepted
+- **Date**: 2026-07-16
+
+---
+
+## Context
+
+`JsonLineLoader` needs to write to a `Stream` it does not own, meaning `StreamWriter` must be constructed with `leaveOpen: true` so it does not close the caller's stream on dispose. The convenient `new StreamWriter(stream, leaveOpen: true)` constructor was introduced in .NET 6 and is not available on net462, netstandard2.0, or net481. A cross-TFM strategy is required.
+
+---
+
+## Decision
+
+We will use a `#if` preprocessor guard in `CreateStreamWriter` to call different constructors depending on the target framework. Modern TFMs (net6+) use the clean `leaveOpen: true` two-argument overload. Older TFMs use the five-argument overload `new StreamWriter(stream, Encoding.UTF8, 1024, leaveOpen: true)`.
+
+---
+
+## Considered Options
+
+### Option A: Always use the 5-arg overload
+
+- Pro: Compiles on all TFMs without `#if`.
+- Con: `Encoding.UTF8` on older frameworks writes a UTF-8 BOM, which is incorrect for most JSON consumers.
+- Con: Forces BOM behavior even on modern TFMs where a cleaner API exists.
+
+### Option B: `#if` guard (chosen)
+
+- Pro: Modern TFMs (net6+) use the clean 2-arg constructor — no BOM, no magic buffer size.
+- Pro: Older TFMs compile and run correctly using the 5-arg form.
+- Con: Older TFMs (net462, netstandard2.0, net481) emit a UTF-8 BOM at the start of each stream — this is a documented behavior difference.
+- Con: Test suite must strip the BOM (via `TrimStart('﻿')`) when comparing output across TFMs.
+
+---
+
+## Consequences
+
+**Easier:**
+
+- Consumers on net6+ get clean, BOM-free JSON output with no special handling required.
+- The library compiles and runs correctly across the full TFM matrix without runtime fallbacks.
+
+**Harder:**
+
+- `JsonLineLoader` writes a UTF-8 BOM on net462, netstandard2.0, and net481; consumers on those TFMs should use a BOM-aware parser or set an explicit `Encoding.UTF8` (which strips the BOM on read).
+- The test suite's cross-TFM comparison logic must account for the BOM; do not remove the `TrimStart` call without re-examining the full TFM test matrix.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,44 @@
+# ADR-NNN Short title in noun form
+
+- **Status**: Proposed | Accepted | Superseded by ADR-NNN | Deprecated
+- **Date**: YYYY-MM-DD
+
+---
+
+## Context
+
+_(Describe the situation, forces, and constraints that make a decision necessary. What problem are we solving? What requirements or pressures are at play?)_
+
+---
+
+## Decision
+
+_(State the decision that was made. Use active voice: "We will use X" or "We decided to Y".)_
+
+---
+
+## Considered Options
+
+### Option A: [Name]
+
+- Pro: _(benefit)_
+- Pro: _(benefit)_
+- Con: _(drawback)_
+
+### Option B: [Name]
+
+- Pro: _(benefit)_
+- Con: _(drawback)_
+- Con: _(drawback)_
+
+---
+
+## Consequences
+
+**Easier:**
+
+- _(What becomes easier or better as a result of this decision?)_
+
+**Harder:**
+
+- _(What becomes harder or is accepted as a trade-off?)_

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,11 @@
+# Architecture Decision Records
+
+| Number | Title | Status | Date |
+|--------|-------|--------|------|
+| [ADR-001](ADR-001-system-text-json.md) | System.Text.Json over Newtonsoft.Json | Accepted | 2026-07-16 |
+| [ADR-002](ADR-002-sync-writeline-loader-hot-path.md) | Sync StreamWriter.WriteLine in loader hot paths | Accepted | 2026-07-16 |
+| [ADR-003](ADR-003-leaveopen-streamwriter-compat.md) | `#if` guards in CreateStreamWriter for leaveOpen compat | Accepted | 2026-07-16 |
+
+---
+
+To add a new ADR, copy [TEMPLATE.md](TEMPLATE.md), assign the next number, and add a row to this table.

--- a/docs/migrations/TEMPLATE-major-version-migration.md
+++ b/docs/migrations/TEMPLATE-major-version-migration.md
@@ -1,0 +1,66 @@
+# Migrating from vX.Y to vA.B
+
+## Prerequisites
+
+Install the new NuGet package:
+
+```
+dotnet add package Wolfgang.Etl.Json --version A.B.0
+```
+
+---
+
+## Breaking Changes
+
+| API | Before | After | Reason |
+|-----|--------|-------|--------|
+| `ExampleType.OldMethod()` | `void OldMethod()` | `Task OldMethodAsync()` | Async I/O requirement |
+| _(add rows as needed)_ | | | |
+
+---
+
+## Deprecations
+
+| Deprecated API | Replacement | Removed In |
+|----------------|-------------|------------|
+| `ExampleType.OldProperty` | `ExampleType.NewProperty` | vB.0 |
+| _(add rows as needed)_ | | |
+
+---
+
+## Before / After Code Samples
+
+_(Maintainer: add representative before/after snippets for each breaking change.)_
+
+### Example: [Change name]
+
+**Before (vX.Y):**
+
+```csharp
+// TODO
+```
+
+**After (vA.B):**
+
+```csharp
+// TODO
+```
+
+---
+
+## Notable Behavior Changes
+
+- _(List any changes to observable behavior that are not API-level breaks — e.g. BOM handling, encoding defaults, error messages.)_
+
+---
+
+## Deprecation Timeline
+
+| Version | Action |
+|---------|--------|
+| vA.B | Deprecated APIs marked with `[Obsolete]` |
+| vB.0 | Deprecated APIs removed |
+
+---
+
+> **Reminder for maintainers**: Link this guide in the GitHub Release notes for the vA.B release.


### PR DESCRIPTION
## Summary

### ADRs (closes #137)
- `docs/adr/TEMPLATE.md` — MADR template for future decisions
- `docs/adr/index.md` — running index with status/date
- `docs/adr/ADR-001-system-text-json.md` — why System.Text.Json over Newtonsoft (AOT, zero dep, throughput)
- `docs/adr/ADR-002-sync-writeline-loader-hot-path.md` — why sync `WriteLine` in the loader hot path (per-item async state machine allocation avoidance)
- `docs/adr/ADR-003-leaveopen-streamwriter-compat.md` — why the `#if` guard in `CreateStreamWriter` (leaveOpen constructor unavailable pre-.NET 6; BOM behavior on older TFMs)

### Migration guide template (closes #136)
- `docs/migrations/TEMPLATE-major-version-migration.md` — establishes the convention for breaking-release migration guides before they're needed

## Test plan

- [ ] Verify all links in `docs/adr/index.md` resolve
- [ ] Read through ADRs for accuracy

Closes #136, Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)