### PR TITLE
refactor: remove StreamWriter from JsonLineLoader — write directly to stream

### DIFF
--- a/docs/adr/ADR-002-sync-writeline-loader-hot-path.md
+++ b/docs/adr/ADR-002-sync-writeline-loader-hot-path.md
@@ -1,6 +1,6 @@
 # ADR-002 Sync StreamWriter.WriteLine in Loader Hot Paths
 
-- **Status**: Accepted
+- **Status**: Superseded by removal of StreamWriter (2026-07-16)
 - **Date**: 2026-07-16
 
 ---
@@ -45,3 +45,11 @@ We will use synchronous `writer.WriteLine(json)` inside async methods, suppressi
 
 - Two analyzer suppressions (`CA1849`, `AsyncFixer02`) are required above each affected method; these are intentional and must not be removed without revisiting the allocation trade-off.
 - Reviewers unfamiliar with this ADR may flag the suppressions; this document serves as the authoritative explanation.
+
+---
+
+## Update — Superseded (2026-07-16)
+
+`JsonLineLoader` no longer uses `StreamWriter`. It writes directly to `_stream` via `Stream.WriteAsync`, using `JsonSerializer.SerializeToUtf8Bytes` to avoid a string intermediary in the UTF-8 (default) path. The sync/async write trade-off documented here no longer applies: `Stream.WriteAsync` is the correct call and carries no analyzer suppressions.
+
+The `#pragma warning disable CA1849, AsyncFixer02` blocks have been removed from `JsonLineLoader`. `JsonMultiStreamLoader` serializes via `Utf8JsonWriter` directly onto its stream and was not affected by this ADR.

--- a/docs/adr/ADR-003-leaveopen-streamwriter-compat.md
+++ b/docs/adr/ADR-003-leaveopen-streamwriter-compat.md
@@ -1,53 +1,35 @@
 # ADR-003 `#if` Guards in CreateStreamWriter for leaveOpen Compat
 
-- **Status**: Accepted
+- **Status**: Superseded — StreamWriter removed (2026-07-16)
 - **Date**: 2026-07-16
-- **Updated**: 2026-07-16 (BOM issue resolved — see Update section)
 
 ---
 
 ## Context
 
-`JsonLineLoader` needs to write to a `Stream` it does not own, meaning `StreamWriter` must be constructed with `leaveOpen: true` so it does not close the caller's stream on dispose. The convenient `new StreamWriter(stream, leaveOpen: true)` constructor was introduced in .NET 6 and is not available on net462, netstandard2.0, or net481. A cross-TFM strategy is required.
+`JsonLineLoader` needed to write to a `Stream` it does not own, meaning `StreamWriter` had to be constructed with `leaveOpen: true` so it would not close the caller's stream on dispose. The 2-arg `new StreamWriter(stream, leaveOpen: true)` constructor was introduced in .NET 6 and was not available on net462, netstandard2.0, or net481. A cross-TFM strategy was required.
 
 ---
 
-## Decision
+## Decision (original)
 
-We use a `#if` preprocessor guard in `CreateStreamWriter` to call different constructors depending on the target framework. Modern TFMs (net6+) use the clean `leaveOpen: true` two-argument overload. Older TFMs use the five-argument overload with `new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)` to suppress the BOM preamble.
-
----
-
-## Considered Options
-
-### Option A: Always use the 5-arg overload
-
-- Pro: Compiles on all TFMs without `#if`.
-- Con: Forces a magic buffer size even on modern TFMs where a cleaner API exists.
-
-### Option B: `#if` guard (chosen)
-
-- Pro: Modern TFMs (net6+) use the clean 2-arg constructor — no buffer size, no encoding ceremony.
-- Pro: Older TFMs compile and run correctly using the 5-arg form.
-- Con: Slightly more code to maintain across the `#if` boundary.
+A `#if` preprocessor guard in `CreateStreamWriter` called different constructors depending on the target framework. Modern TFMs (net6+) used the 2-arg overload. Older TFMs used the 5-arg overload, which required passing `Encoding.UTF8` — causing a UTF-8 BOM to be written on those TFMs.
 
 ---
 
-## Consequences
+## Update — Superseded (2026-07-16)
 
-**Easier:**
+`JsonLineLoader` no longer uses `StreamWriter` at all. The caller passes in a `Stream` they own; wrapping it in a `StreamWriter` (which disposes the stream on its own dispose) was the wrong approach from the start.
 
-- All TFMs produce BOM-free JSON output.
-- The library compiles and runs correctly across the full TFM matrix without runtime fallbacks.
+The replacement writes directly to `_stream`:
+- UTF-8 path (default): `JsonSerializer.SerializeToUtf8Bytes` + `Stream.WriteAsync`
+- Custom encoding path: `JsonSerializer.Serialize` (string) + `Encoding.GetBytes` + `Stream.WriteAsync`
 
-**Harder:**
-
-- The `#if` guard must be maintained when TFM targets change.
-
----
-
-## Update — BOM issue resolved (2026-07-16)
-
-The original draft of this ADR noted that the 5-arg constructor path (older TFMs) passed `System.Text.Encoding.UTF8`, which writes a UTF-8 BOM preamble. This caused observable output differences and required `TrimStart('﻿')` workarounds in the snapshot test suite.
-
-**Fix (issue #227):** The 5-arg path now passes `new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)`, which is available on all TFMs including net462 and netstandard2.0, and produces BOM-free output. The `TrimStart` workaround has been removed. Both `#if` branches now produce identical, BOM-free output.
+This eliminates:
+- `leaveOpen: true` (no wrapper to close the stream)
+- The `#if` guard (no constructor variation needed)
+- The UTF-8 BOM (no `Encoding.UTF8` reference)
+- `CreateStreamWriter` method
+- The `TrimStart('﻿')` workaround in snapshot tests
+- `CA1849`/`AsyncFixer02` suppressions (writes are now genuinely async)
+- The explicit `FlushAsync` call (no intermediate buffer to flush)

--- a/src/Wolfgang.Etl.Json/JsonLineLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineLoader.cs
@@ -32,6 +32,7 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>, I
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSONL loading of {typeof(TRecord).Name}";
+    private static readonly byte[] _newLineUtf8 = System.Text.Encoding.UTF8.GetBytes(Environment.NewLine);
     private readonly Stream _stream;
     private readonly JsonSerializerOptions? _options;
     private readonly JsonTypeInfo<TRecord>? _typeInfo;
@@ -221,7 +222,7 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>, I
     {
         JsonLogMessages.StartingOperation(_logger, OperationName, null);
 
-        using var writer = IsDryRun ? null : CreateStreamWriter();
+        var newLine = Encoding is null ? _newLineUtf8 : Encoding.GetBytes(Environment.NewLine);
 
         await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
         {
@@ -242,48 +243,33 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>, I
 
             Interlocked.Increment(ref _currentLineNumber);
 
-            if (writer is not null)
+            if (!IsDryRun)
             {
-                var json = _typeInfo is not null
-                    ? JsonSerializer.Serialize(item, _typeInfo)
-                    : JsonSerializer.Serialize(item, _options);
+                byte[] bytes;
 
-#pragma warning disable CA1849, S6966, VSTHRD103, AsyncFixer02 // Sync WriteLine avoids async state machine allocation per item
-                writer.WriteLine(json);
-#pragma warning restore CA1849, S6966, VSTHRD103, AsyncFixer02
+                if (Encoding is null)
+                {
+                    bytes = _typeInfo is not null
+                        ? JsonSerializer.SerializeToUtf8Bytes(item, _typeInfo)
+                        : JsonSerializer.SerializeToUtf8Bytes(item, _options);
+                }
+                else
+                {
+                    var json = _typeInfo is not null
+                        ? JsonSerializer.Serialize(item, _typeInfo)
+                        : JsonSerializer.Serialize(item, _options);
+                    bytes = Encoding.GetBytes(json);
+                }
+
+                await _stream.WriteAsync(bytes, offset: 0, count: bytes.Length, token).ConfigureAwait(false);
+                await _stream.WriteAsync(newLine, offset: 0, count: newLine.Length, token).ConfigureAwait(false);
             }
 
             IncrementCurrentItemCount();
             JsonLogMessages.LoadedItemAtLine(_logger, CurrentItemCount, Interlocked.Read(ref _currentLineNumber), null);
         }
 
-        if (writer is not null)
-        {
-#if NETSTANDARD2_0 || NET462 || NET481
-#pragma warning disable CA2016, MA0040 // FlushAsync(CancellationToken) not available on this TFM
-            await writer.FlushAsync().ConfigureAwait(false);
-#pragma warning restore CA2016, MA0040
-#else
-            await writer.FlushAsync(token).ConfigureAwait(false);
-#endif
-        }
-
         JsonLogMessages.JsonlLoadingCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, Interlocked.Read(ref _currentLineNumber), null);
-    }
-
-
-
-    private StreamWriter CreateStreamWriter()
-    {
-#if NETSTANDARD2_0 || NET462 || NET481
-        return Encoding is null
-            ? new StreamWriter(_stream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false), bufferSize: 1024, leaveOpen: true)
-            : new StreamWriter(_stream, Encoding, bufferSize: 1024, leaveOpen: true);
-#else
-        return Encoding is null
-            ? new StreamWriter(_stream, leaveOpen: true)
-            : new StreamWriter(_stream, Encoding, bufferSize: 1024, leaveOpen: true);
-#endif
     }
 
 


### PR DESCRIPTION
## Summary

The caller owns the stream; `StreamWriter` was the wrong tool because it disposes the underlying stream when it's disposed, requiring `leaveOpen: true` and a TFM-conditional `#if` guard to work around it. Writing directly to `_stream` sidesteps the entire problem.

**Removed:**
- `CreateStreamWriter` method and the `#if NETSTANDARD2_0 || NET462 || NET481` guard
- `leaveOpen: true` (no wrapper to dispose the stream anymore)
- UTF-8 BOM issue (no `Encoding.UTF8` reference in the write path)
- `TrimStart('﻿')` workaround in `JsonOutputSnapshotTests`
- `#pragma warning disable CA1849, AsyncFixer02` suppressions (writes are now genuinely async)
- Explicit `FlushAsync` call (no intermediate StreamWriter buffer)

**Replaced with:**
- UTF-8 path (default): `JsonSerializer.SerializeToUtf8Bytes` + `Stream.WriteAsync`
- Custom `Encoding` path: `JsonSerializer.Serialize` (string) + `Encoding.GetBytes` + `Stream.WriteAsync`

ADR-002 and ADR-003 updated to superseded status.

Supersedes #228 (BOM fix — that approach is now unnecessary). Closes #227.

## Test plan

- [x] All 425 tests pass across all TFMs (net462 through net10.0) locally with Release build
- [ ] CI green