### PR TITLE
ci: add/update workflows for v0.4.0 (protected-only, ahead of #231)

### DIFF
--- a/.github/workflows/aot-smoke.yaml
+++ b/.github/workflows/aot-smoke.yaml
@@ -1,0 +1,119 @@
+# AOT / trim publish smoke test.
+#
+# Publishes examples/Wolfgang.Etl.Json.Example.AotSmoke with
+# <PublishAot>true</PublishAot> + <PublishTrimmed>true</PublishTrimmed>
+# and runs the resulting native binary. Surfaces IL2xxx / AOT0xxx /
+# IL3xxx warnings so we know which library surfaces the trimmer /
+# AOT compiler can't see through.
+#
+# The library's JsonTypeInfo<T> overloads (used by the smoke example)
+# carry [RequiresDynamicCode] / [RequiresUnreferencedCode] guards on the
+# reflection-based overloads, so AOT-clean paths are explicitly marked.
+# This workflow verifies those paths produce a runnable binary.
+#
+# Status: INFORMATIONAL / NON-BLOCKING today (continue-on-error).
+# Refs #130.
+name: AOT + trim smoke
+
+on:
+  pull_request_target:
+    paths:
+      - "src/**"
+      - "examples/Wolfgang.Etl.Json.Example.AotSmoke/**"
+      - ".github/workflows/aot-smoke.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "examples/Wolfgang.Etl.Json.Example.AotSmoke/**"
+      - ".github/workflows/aot-smoke.yaml"
+  workflow_dispatch:
+
+jobs:
+  aot-smoke:
+    name: PublishAot + PublishTrimmed
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore examples/Wolfgang.Etl.Json.Example.AotSmoke/Wolfgang.Etl.Json.Example.AotSmoke.csproj
+
+      - name: Publish (PublishAot + PublishTrimmed)
+        id: publish
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          mkdir -p publish
+          dotnet publish \
+            examples/Wolfgang.Etl.Json.Example.AotSmoke/Wolfgang.Etl.Json.Example.AotSmoke.csproj \
+            --configuration Release \
+            --runtime linux-x64 \
+            --self-contained true \
+            --output publish \
+            -p:PublishAot=true \
+            -p:PublishTrimmed=true \
+            -p:TrimmerSingleWarn=false \
+            2>&1 | tee publish.log
+
+      - name: Summarize trim / AOT warnings
+        if: always()
+        run: |
+          {
+            echo "## AOT + trim smoke — warning summary"
+            echo ""
+            if [ ! -f publish.log ]; then
+              echo "publish step produced no log — likely errored before running dotnet."
+              exit 0
+            fi
+            il2_count=$(grep -c "warning IL2" publish.log || true)
+            il3_count=$(grep -c "warning IL3" publish.log || true)
+            aot_count=$(grep -c "warning AOT" publish.log || true)
+            echo "| Category | Count |"
+            echo "|---|---|"
+            echo "| Trim (IL2xxx) | $il2_count |"
+            echo "| Single-file (IL3xxx) | $il3_count |"
+            echo "| AOT (AOT0xxx) | $aot_count |"
+            echo ""
+            if [ "$il2_count" -gt 0 ] || [ "$il3_count" -gt 0 ] || [ "$aot_count" -gt 0 ]; then
+              echo "<details><summary>First 20 warnings</summary>"
+              echo ""
+              echo '```'
+              grep -E "warning (IL[23]|AOT)" publish.log | head -20
+              echo '```'
+              echo ""
+              echo "</details>"
+            fi
+            echo ""
+            echo "**Gate mode**: non-blocking (informational). Promote to blocking once IL2xxx count reaches zero."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run the AOT-published binary
+        if: steps.publish.outcome == 'success'
+        run: |
+          bin=publish/Wolfgang.Etl.Json.Example.AotSmoke
+          if [ ! -x "$bin" ]; then
+            echo "::warning::AOT-published binary not found at $bin — publish output layout may have changed."
+            exit 0
+          fi
+          "$bin"
+
+      - name: Upload publish log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: aot-smoke-publish-log
+          path: publish.log
+          retention-days: 30

--- a/.github/workflows/pr-benchmarks.yaml
+++ b/.github/workflows/pr-benchmarks.yaml
@@ -1,0 +1,219 @@
+name: PR Benchmarks
+
+# Runs BenchmarkDotNet on both the PR HEAD and the base branch tip, then posts
+# a delta table as a PR comment (replacing it on each push).  Fails the PR if
+# any benchmark regresses beyond the configured thresholds unless the PR carries
+# the perf-impact-acknowledged label.
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'benchmarks/**'
+      - '.github/workflows/pr-benchmarks.yaml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BENCH_PROJECT: benchmarks/Wolfgang.Etl.Json.Benchmarks/Wolfgang.Etl.Json.Benchmarks.csproj
+  BENCH_DIR: benchmarks/Wolfgang.Etl.Json.Benchmarks
+
+jobs:
+  benchmark-delta:
+    name: BDN delta (HEAD vs base)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: |
+            10.0.x
+
+      # ── Base run ──────────────────────────────────────────────────────────
+
+      - name: Run benchmarks on base (${{ github.event.pull_request.base.sha }})
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }}
+          dotnet restore "$BENCH_PROJECT"
+          dotnet build -c Release --no-restore "$BENCH_PROJECT"
+          cd "$BENCH_DIR"
+          dotnet run -c Release --no-build -- --filter "*" --job short --memory --exporters json
+          shopt -s nullglob
+          reports=(BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json)
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "::error::No BDN JSON produced for base run"
+            exit 1
+          fi
+          jq -s '{Title:"base",HostEnvironmentInfo:.[0].HostEnvironmentInfo,Benchmarks:[.[].Benchmarks[]]}' \
+            "${reports[@]}" > /tmp/bdn-base.json
+
+      # ── HEAD run ──────────────────────────────────────────────────────────
+
+      - name: Run benchmarks on HEAD (${{ github.event.pull_request.head.sha }})
+        run: |
+          git checkout ${{ github.event.pull_request.head.sha }}
+          rm -rf "$BENCH_DIR/BenchmarkDotNet.Artifacts"
+          dotnet restore "$BENCH_PROJECT"
+          dotnet build -c Release --no-restore "$BENCH_PROJECT"
+          cd "$BENCH_DIR"
+          dotnet run -c Release --no-build -- --filter "*" --job short --memory --exporters json
+          shopt -s nullglob
+          reports=(BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json)
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "::error::No BDN JSON produced for HEAD run"
+            exit 1
+          fi
+          jq -s '{Title:"head",HostEnvironmentInfo:.[0].HostEnvironmentInfo,Benchmarks:[.[].Benchmarks[]]}' \
+            "${reports[@]}" > /tmp/bdn-head.json
+
+      # ── Delta + comment ───────────────────────────────────────────────────
+
+      - name: Compute delta and post PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          MEAN_THRESHOLD: '20'
+          ALLOC_THRESHOLD: '50'
+          EXEMPT_LABEL: perf-impact-acknowledged
+        run: |
+          node << 'NODEJS'
+          const fs = require('fs');
+          const { execFileSync } = require('child_process');
+
+          const base = JSON.parse(fs.readFileSync('/tmp/bdn-base.json', 'utf8'));
+          const head = JSON.parse(fs.readFileSync('/tmp/bdn-head.json', 'utf8'));
+
+          const baseLookup = Object.fromEntries(
+            base.Benchmarks.map(b => [b.FullName, b])
+          );
+
+          const MEAN_THRESHOLD = parseFloat(process.env.MEAN_THRESHOLD);
+          const ALLOC_THRESHOLD = parseFloat(process.env.ALLOC_THRESHOLD);
+          const EXEMPT_LABEL = process.env.EXEMPT_LABEL;
+          const labels = JSON.parse(process.env.PR_LABELS || '[]');
+          const isExempt = labels.includes(EXEMPT_LABEL);
+
+          function fmtTime(ns) {
+            if (ns < 1000) return ns.toFixed(1) + ' ns';
+            if (ns < 1e6) return (ns / 1000).toFixed(2) + ' μs';
+            if (ns < 1e9) return (ns / 1e6).toFixed(2) + ' ms';
+            return (ns / 1e9).toFixed(3) + ' s';
+          }
+
+          function fmtBytes(b) {
+            if (b === 0 || b === null || b === undefined) return '0 B';
+            if (b < 1024) return b + ' B';
+            if (b < 1048576) return (b / 1024).toFixed(1) + ' KB';
+            return (b / 1048576).toFixed(2) + ' MB';
+          }
+
+          function fmtDelta(pct) {
+            const sign = pct > 0 ? '+' : '';
+            return sign + pct.toFixed(1) + '%';
+          }
+
+          function trafficLight(pct, threshold) {
+            if (pct > threshold) return '🔴';
+            if (pct > threshold / 2) return '🟡';
+            if (pct < -5) return '🟢';
+            return '⚪';
+          }
+
+          const rows = [];
+          let hasRegression = false;
+
+          for (const hb of head.Benchmarks) {
+            const bb = baseLookup[hb.FullName];
+            if (!bb) continue;
+
+            const headMean = hb.Statistics.Mean;
+            const baseMean = bb.Statistics.Mean;
+            const headAlloc = hb.Memory?.BytesAllocatedPerOperation ?? 0;
+            const baseAlloc = bb.Memory?.BytesAllocatedPerOperation ?? 0;
+
+            const deltaMean = baseMean > 0 ? ((headMean - baseMean) / baseMean * 100) : 0;
+            const deltaAlloc = baseAlloc > 0 ? ((headAlloc - baseAlloc) / baseAlloc * 100) : 0;
+
+            if (deltaMean > MEAN_THRESHOLD || deltaAlloc > ALLOC_THRESHOLD) {
+              hasRegression = true;
+            }
+
+            const parts = hb.FullName.split('.');
+            const shortName = parts.slice(-2).join('.');
+
+            rows.push(
+              `| ${shortName} ` +
+              `| ${fmtTime(baseMean)} | ${fmtTime(headMean)} | ${trafficLight(deltaMean, MEAN_THRESHOLD)} ${fmtDelta(deltaMean)} ` +
+              `| ${fmtBytes(baseAlloc)} | ${fmtBytes(headAlloc)} | ${trafficLight(deltaAlloc, ALLOC_THRESHOLD)} ${fmtDelta(deltaAlloc)} |`
+            );
+          }
+
+          const baseSha = process.env.BASE_SHA.slice(0, 7);
+          const headSha = process.env.HEAD_SHA.slice(0, 7);
+
+          let verdict;
+          if (hasRegression && !isExempt) {
+            verdict = `> ⚠️ **Regression detected.** At least one benchmark exceeded the threshold (>${MEAN_THRESHOLD}% mean or >${ALLOC_THRESHOLD}% alloc). Add the \`${EXEMPT_LABEL}\` label to acknowledge intentional perf impact.`;
+          } else if (hasRegression) {
+            verdict = `> ℹ️ Regression present but acknowledged via \`${EXEMPT_LABEL}\` label.`;
+          } else {
+            verdict = '> ✅ No regressions detected.';
+          }
+
+          const body = [
+            '<!-- bdn-delta -->',
+            '## BenchmarkDotNet — PR delta',
+            '',
+            `Comparing \`${baseSha}\` (base) → \`${headSha}\` (HEAD)`,
+            `Thresholds: mean >${MEAN_THRESHOLD}% = 🔴, alloc >${ALLOC_THRESHOLD}% = 🔴`,
+            '',
+            '| Benchmark | Base mean | HEAD mean | Δ mean | Base alloc | HEAD alloc | Δ alloc |',
+            '|-----------|----------:|----------:|-------:|-----------:|-----------:|--------:|',
+            ...rows,
+            '',
+            verdict,
+          ].join('\n');
+
+          fs.writeFileSync('/tmp/bdn-comment.json', JSON.stringify({ body }));
+
+          const existing = execFileSync('gh', [
+            'api', `repos/${process.env.REPO}/issues/${process.env.PR_NUMBER}/comments`,
+            '--jq', '[.[] | select(.body | startswith("<!-- bdn-delta -->"))] | first | .id // empty',
+          ], { encoding: 'utf8' }).trim();
+
+          if (existing) {
+            execFileSync('gh', [
+              'api', `repos/${process.env.REPO}/issues/comments/${existing}`,
+              '--method', 'PATCH', '--input', '/tmp/bdn-comment.json',
+            ]);
+            console.log('Updated comment', existing);
+          } else {
+            execFileSync('gh', [
+              'api', `repos/${process.env.REPO}/issues/${process.env.PR_NUMBER}/comments`,
+              '--method', 'POST', '--input', '/tmp/bdn-comment.json',
+            ]);
+            console.log('Posted new comment');
+          }
+
+          if (hasRegression && !isExempt) {
+            console.error('::error::Performance regression detected — see PR comment for details');
+            process.exit(1);
+          }
+          NODEJS

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1412,8 +1412,117 @@ jobs:
           echo "Stage 1: Linux tests + 90% coverage ✅"
           echo "Stage 2: Windows .NET Core & .NET Framework tests ✅"
           echo "Stage 3: macOS tests ✅"
+          echo "Stage 4: Linux ARM64 tests ✅ (runs parallel to Stage 3)"
           echo ""
           echo "PR is ready to merge! 🎉"
+
+  # ============================================================================
+  # STAGE 4: Linux ARM64 Tests (Gated by Stage 2, runs parallel to Stage 3)
+  # ============================================================================
+  test-linux-arm64:
+    name: "Stage 4: Linux ARM64 Tests (.NET 5.0-10.0)"
+    runs-on: ubuntu-24.04-arm
+    needs: [detect-projects, test-windows]
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Fetch trusted configuration files from main branch
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        run: |
+          git fetch origin main:main-branch
+          config_files=(
+            ".editorconfig"
+            "Directory.Build.props"
+            "Directory.Build.targets"
+            "BannedSymbols.txt"
+            "*.globalconfig"
+            "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
+          )
+          for config_file in "${config_files[@]}"; do
+            if [[ "$config_file" == *"*"* ]]; then
+              while read -r file; do
+                if [ -n "$file" ]; then
+                  mkdir -p "$(dirname "$file")"
+                  if ! git show "main-branch:$file" > "$file"; then
+                    echo "::error::Failed to copy $file from main-branch"
+                    exit 1
+                  fi
+                fi
+              done < <(git ls-tree -r --name-only main-branch | { grep -E "${config_file//\*/.*}" || true; })
+            else
+              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
+                mkdir -p "$(dirname "$config_file")"
+                git show "main-branch:$config_file" > "$config_file"
+              fi
+            fi
+          done
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: |
+            5.0.x
+            6.0.x
+            7.0.x
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Restore and build
+        run: |
+          dotnet restore
+          dotnet build --no-restore --configuration Release
+
+      - name: Run tests (.NET 5.0-10.0)
+        run: |
+          test_projects=()
+          while IFS= read -r proj; do
+            test_projects+=("$proj")
+          done < <(find ./tests -name '*.csproj' -not -name '*.Docs.*' -not -name '*.Integration.*' 2>/dev/null || true)
+
+          if [ ${#test_projects[@]} -eq 0 ]; then
+            echo "No test projects found — skipping"
+            exit 0
+          fi
+
+          for proj in "${test_projects[@]}"; do
+            echo "=========================================="
+            echo "Testing: $proj"
+            echo "=========================================="
+            for fw in net5.0 net6.0 net7.0 net8.0 net9.0 net10.0; do
+              if dotnet test "$proj" --configuration Release --framework "$fw" \
+                  --no-build --no-restore \
+                  --logger "console;verbosity=minimal" 2>/dev/null; then
+                echo "  ✅ $fw passed"
+              else
+                rc=$?
+                # Skip if framework isn't targeted by this project
+                if dotnet test "$proj" --configuration Release --framework "$fw" \
+                    --list-tests --no-build 2>&1 | grep -q "No test"; then
+                  echo "  ⏭️  $fw not targeted"
+                else
+                  echo "  ❌ $fw failed"
+                  exit $rc
+                fi
+              fi
+            done
+          done
+          echo ""
+          echo "✅ All ARM64 tests passed"
+
+      - name: Display ARM64 architecture info
+        if: always()
+        run: |
+          echo "Runner architecture: $(uname -m)"
+          echo "OS: $(uname -s -r)"
 
   # ============================================================================
   # Integration Tests (Runs after Linux core tests on net8.0 and net10.0)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -375,6 +375,13 @@ jobs:
           dotnet restore
           dotnet build --no-restore --configuration Release
 
+      - name: Check ABI compatibility (ApiCompat)
+        shell: pwsh
+        run: |
+          dotnet tool install -g Microsoft.DotNet.ApiCompat.Tool
+          $env:PATH += [IO.Path]::PathSeparator + (Join-Path $env:USERPROFILE '.dotnet/tools')
+          ./scripts/Check-ApiCompatibility.ps1 -Configuration Release
+
       - name: Pack NuGet packages
         id: check-packages
         shell: pwsh
@@ -561,6 +568,25 @@ jobs:
           }
 
 
+      - name: Generate reproducible-build hash manifest
+        if: steps.check-packages.outputs.has-packages == 'true'
+        shell: pwsh
+        env:
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          $artifacts = Get-ChildItem -Path 'nuget-packages' -Include '*.nupkg','*.snupkg' -Recurse -ErrorAction SilentlyContinue
+          $entries = $artifacts | ForEach-Object {
+            $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLower()
+            [ordered]@{ name = $_.Name; sha256 = $hash }
+          }
+          $manifest = [ordered]@{
+            version   = ($env:RELEASE_TAG_NAME -replace '^v\.?', '')
+            artifacts = @($entries)
+          }
+          $manifest | ConvertTo-Json -Depth 5 |
+            Out-File -FilePath 'nuget-packages/reproducible-build-manifest.json' -Encoding utf8NoBOM
+          Write-Host "✅ Hash manifest written" -ForegroundColor Green
+
       - name: Upload NuGet packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -739,6 +765,38 @@ jobs:
           Write-Host "✅ All packages published to NuGet.org" -ForegroundColor Green
           Write-Host "==========================================" -ForegroundColor Green
 
+  # SLSA build provenance attestation — proves the .nupkg / .snupkg
+  # attached to the Release were built by THIS workflow at THIS commit,
+  # signed via GitHub's OIDC identity with Sigstore's keyless CA.
+  # Consumers can verify with:
+  #   gh attestation verify <pkg>.nupkg --owner Chris-Wolfgang --repo ETL-Json
+  # See SECURITY.md for full verification instructions.
+  # Closes #125
+  attest-build-provenance:
+    name: Attest build provenance (SLSA)
+    needs: [pack-and-validate, publish-nuget]
+    if: needs.pack-and-validate.outputs.has-packages == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write      # OIDC token for Sigstore keyless signing
+      contents: read
+      attestations: write  # required to write attestation to the repo
+
+    steps:
+      - name: Download packed artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: nuget-packages
+          path: ./packages
+
+      - name: Attest .nupkg / .snupkg provenance
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v3.0.0
+        with:
+          subject-path: |
+            packages/*.nupkg
+            packages/*.snupkg
+
+
   # Build and deploy versioned documentation via the shared docfx workflow
   # Note: reusable workflow jobs called via `uses:` do not require `runs-on` in the caller
   trigger-docs:
@@ -782,5 +840,6 @@ jobs:
             ./nuget-packages/*.nupkg
             ./nuget-packages/*.snupkg
             ./nuget-packages/*.bom.json
+            ./nuget-packages/reproducible-build-manifest.json
             release-coverage.zip
 

--- a/.github/workflows/sourcelink.yaml
+++ b/.github/workflows/sourcelink.yaml
@@ -1,0 +1,101 @@
+name: SourceLink
+
+# End-to-end SourceLink verification (#131).
+#
+# Directory.Build.props enables Microsoft.SourceLink.GitHub + EmbedUntrackedSources
+# and the release packs .snupkg symbol packages. That embeds, into every PDB, a
+# map from each source document to its raw.githubusercontent.com URL at the build
+# commit. If a release mis-tags the commit or the SourceLink map is wrong, a
+# consumer's "step into library source" (F11) silently falls back to a decompiled
+# assembly — and nothing catches it today.
+#
+# `dotnet sourcelink test` closes that gap without needing a live debugger: for
+# every document referenced by the PDB it fetches the mapped GitHub URL and fails
+# unless the downloaded content's checksum matches the one embedded in the PDB.
+# That exercises the exact chain that step-into depends on — commit-SHA embedded
+# in the PDB + GitHub raw-URL resolution. Embedded (untracked) documents need no
+# URL and are verified in place. The PDB tested here is byte-identical to the one
+# shipped inside the .snupkg, so this covers the symbol-package path too.
+#
+# Runs on PRs so a SourceLink regression is caught before it can ship, using the
+# PR's pushed commit (whose raw URLs resolve on GitHub).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sourcelink-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sourcelink:
+    name: Verify SourceLink
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Detect src projects
+        id: detect
+        run: |
+          if git ls-files 'src/**/*.csproj' 'src/*.csproj' | grep -q .; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No src/**/*.csproj found — skipping SourceLink verification."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.detect.outputs.found == 'true'
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: '10.0.x'
+
+      # Build each src project (not the whole solution — benchmarks/examples may
+      # target older TFMs only, so `-f net10.0` at the solution level would fail).
+      # ContinuousIntegrationBuild=true normalises source paths exactly as a
+      # release does, so the PDB embeds the same SourceLink map the shipped
+      # package carries.
+      - name: Build src projects (Release, net10.0)
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          while IFS= read -r proj; do
+            echo "== build $proj =="
+            dotnet build "$proj" -c Release -f net10.0 -p:ContinuousIntegrationBuild=true
+          done < <(git ls-files 'src/**/*.csproj' 'src/*.csproj')
+
+      - name: Install sourcelink tool
+        if: steps.detect.outputs.found == 'true'
+        run: dotnet tool install --global sourcelink
+
+      - name: Verify SourceLink resolves for every PDB
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          shopt -s globstar nullglob
+          pdbs=(src/**/bin/Release/net10.0/*.pdb)
+          if [ ${#pdbs[@]} -eq 0 ]; then
+            echo "::error::No PDBs found under src/**/bin/Release/net10.0 — SourceLink cannot be verified."
+            exit 1
+          fi
+          failed=0
+          for pdb in "${pdbs[@]}"; do
+            echo "== sourcelink test $pdb =="
+            if ! sourcelink test "$pdb"; then
+              echo "::error::SourceLink verification failed for $pdb — a debugger would fall back to decompiled source."
+              failed=1
+            fi
+          done
+          if [ "$failed" -ne 0 ]; then
+            exit 1
+          fi
+          echo "✅ SourceLink resolves for all PDBs — step-into will fetch real source from GitHub."


### PR DESCRIPTION
## Summary

Protected-file-only PR ahead of the v0.4.0 release PR (#231). Extracts all 5 workflow changes so #231 can merge via normal CI without an admin bypass on the full diff.

**Protected files changed:**
- `.github/workflows/aot-smoke.yaml` — NEW (AOT/trim smoke test)
- `.github/workflows/pr-benchmarks.yaml` — NEW (per-PR BDN delta gate)
- `.github/workflows/pr.yaml` — updated
- `.github/workflows/release.yaml` — SLSA attestation + reproducible-build manifest
- `.github/workflows/sourcelink.yaml` — NEW (SourceLink PDB verification)

`Detect .NET Projects` will ❌ as expected — **requires admin bypass**.

After this merges, merge main back into vNext so PR #231 loses the protected-file delta and can merge normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)