### PR TITLE
ci: exclude net5.0 from Stage 4 ARM64 (protected-only)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1420,7 +1420,7 @@ jobs:
   # STAGE 4: Linux ARM64 Tests (Gated by Stage 2, runs parallel to Stage 3)
   # ============================================================================
   test-linux-arm64:
-    name: "Stage 4: Linux ARM64 Tests (.NET 5.0-10.0)"
+    name: "Stage 4: Linux ARM64 Tests (.NET 6.0-10.0)"
     runs-on: ubuntu-24.04-arm
     needs: [detect-projects, test-windows]
     if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
@@ -1469,7 +1469,6 @@ jobs:
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: |
-            5.0.x
             6.0.x
             7.0.x
             8.0.x
@@ -1481,7 +1480,7 @@ jobs:
           dotnet restore
           dotnet build --no-restore --configuration Release
 
-      - name: Run tests (.NET 5.0-10.0)
+      - name: Run tests (.NET 6.0-10.0)
         run: |
           test_projects=()
           while IFS= read -r proj; do
@@ -1497,7 +1496,7 @@ jobs:
             echo "=========================================="
             echo "Testing: $proj"
             echo "=========================================="
-            for fw in net5.0 net6.0 net7.0 net8.0 net9.0 net10.0; do
+            for fw in net6.0 net7.0 net8.0 net9.0 net10.0; do
               if dotnet test "$proj" --configuration Release --framework "$fw" \
                   --no-build --no-restore \
                   --logger "console;verbosity=minimal" 2>/dev/null; then


### PR DESCRIPTION
## Summary

`net5.0` fails on `ubuntu-24.04-arm` due to glibc/OpenSSL compatibility issues — this is an EOL runtime with known problems on Ubuntu 24.04 ARM64. net5.0 is already covered by Stage 1 (Linux x64) and Stage 2 (Windows).

**Changes to `pr.yaml`:**
- Stage 4 setup-dotnet: removed `5.0.x`
- Stage 4 test loop: `net5.0 net6.0 ...` → `net6.0 ...`
- Stage 4 job name + step name: updated from `.NET 5.0-10.0` to `.NET 6.0-10.0`

`Detect .NET Projects` will ❌ as expected — **requires admin bypass**.

Fixes the Stage 4 failure blocking PR #231 (vNext → main, v0.4.0 release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)