### PR TITLE
docs: add compressed streams examples and guide

### DIFF
--- a/docs/COMPRESSED-STREAMS.md
+++ b/docs/COMPRESSED-STREAMS.md
@@ -1,0 +1,57 @@
+# Compressed Streams
+
+All extractors and loaders in `Wolfgang.Etl.Json` accept any `Stream` — including compression wrappers from `System.IO.Compression`. No special API is needed: wrap the underlying stream in a `GZipStream`, `BrotliStream`, or `DeflateStream` before passing it to the constructor.
+
+## Load to GZip-compressed JSONL
+
+```csharp
+using var fileStream = File.Create("output.jsonl.gz");
+using var gzipStream = new GZipStream(fileStream, CompressionLevel.Optimal, leaveOpen: true);
+var loader = new JsonLineLoader<Record>(gzipStream);
+await loader.LoadAsync(records);
+```
+
+> **Note:** Pass `leaveOpen: true` to `GZipStream` when the underlying stream is owned by the caller. `GZipStream` disposes the inner stream on its own dispose unless `leaveOpen` is set.
+
+## Extract from GZip-compressed JSONL
+
+```csharp
+using var fileStream = File.OpenRead("data.jsonl.gz");
+using var gzipStream = new GZipStream(fileStream, CompressionMode.Decompress);
+var extractor = new JsonLineExtractor<Record>(gzipStream);
+
+await foreach (var item in extractor.ExtractAsync())
+{
+    Console.WriteLine(item);
+}
+```
+
+## Extract from GZip-compressed JSON array
+
+```csharp
+using var fileStream = File.OpenRead("data.json.gz");
+using var gzipStream = new GZipStream(fileStream, CompressionMode.Decompress);
+var extractor = new JsonSingleStreamExtractor<Record>(gzipStream);
+```
+
+## Brotli variant
+
+```csharp
+using var fileStream = File.OpenRead("data.jsonl.br");
+using var brotliStream = new BrotliStream(fileStream, CompressionMode.Decompress);
+var extractor = new JsonLineExtractor<Record>(brotliStream);
+```
+
+> **Note:** `BrotliStream` requires .NET Core 2.1 or later (`netcoreapp2.1` / `netstandard2.1` / `net5.0+`). It is not available on .NET Framework.
+
+## Choosing a compression format
+
+| Format | Class | Extension | Notes |
+|---|---|---|---|
+| GZip | `GZipStream` | `.gz` | Available on all TFMs including .NET Framework |
+| Brotli | `BrotliStream` | `.br` | .NET Core 2.1+ only; best compression ratio |
+| Deflate | `DeflateStream` | `.deflate` | Available on all TFMs; GZip is usually preferred |
+
+## Runnable example
+
+See `examples/Wolfgang.Etl.Json.Examples/Program.cs` — `CompressedStreamsExample()` for a complete load-then-extract round-trip using GZip.

--- a/examples/Wolfgang.Etl.Json.Examples/Program.cs
+++ b/examples/Wolfgang.Etl.Json.Examples/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
@@ -27,6 +28,8 @@ Console.WriteLine();
 await CustomOptionsExample(loggerFactory);
 Console.WriteLine();
 await SkipAndMaxExample();
+Console.WriteLine();
+await CompressedStreamsExample();
 
 
 
@@ -248,4 +251,41 @@ static async Task SkipAndMaxExample()
     }
 
     Console.WriteLine($"Extracted: {extractor.CurrentItemCount}, Skipped: {extractor.CurrentSkippedItemCount}");
+}
+
+
+
+static async Task CompressedStreamsExample()
+{
+    Console.WriteLine("=== Compressed Streams Example ===");
+    Console.WriteLine("The extractors and loaders accept any Stream, including compression wrappers.");
+    Console.WriteLine();
+
+    var people = new List<Person>
+    {
+        new() { FirstName = "Alice", LastName = "Smith", Age = 30, Email = "alice@example.com" },
+        new() { FirstName = "Bob", LastName = "Jones", Age = 25, Email = "bob@example.com" },
+    };
+
+    // --- Load to GZip-compressed JSONL ---
+    var compressed = new MemoryStream();
+    using (var gzipWrite = new GZipStream(compressed, CompressionLevel.Optimal, leaveOpen: true))
+    {
+        var loader = new JsonLineLoader<Person>(gzipWrite);
+        await loader.LoadAsync(people.ToAsyncEnumerable());
+        Console.WriteLine($"Loaded {loader.CurrentItemCount} items to GZip-compressed JSONL ({compressed.Length} bytes compressed).");
+    }
+
+    // --- Extract back from GZip-compressed JSONL ---
+    compressed.Position = 0;
+    using var gzipRead = new GZipStream(compressed, CompressionMode.Decompress);
+    var extractor = new JsonLineExtractor<Person>(gzipRead);
+
+    Console.WriteLine("Extracted items:");
+    await foreach (var person in extractor.ExtractAsync())
+    {
+        Console.WriteLine($"  {person.FirstName} {person.LastName}, age {person.Age}");
+    }
+
+    Console.WriteLine($"Extracted: {extractor.CurrentItemCount}");
 }


### PR DESCRIPTION
## Summary

Closes #17

- `docs/COMPRESSED-STREAMS.md` — guide covering GZip, Brotli, Deflate wrappers with code snippets, a TFM compatibility table, and a leaveOpen note
- `examples/Wolfgang.Etl.Json.Examples/Program.cs` — `CompressedStreamsExample()`: GZip round-trip (load JSONL → extract back) using `MemoryStream` so it runs without touching the filesystem

No source changes — all extractors/loaders already accept any `Stream`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)