### PR TITLE
docs: add schema customization examples and guide

### DIFF
--- a/docs/SCHEMA-CUSTOMIZATION.md
+++ b/docs/SCHEMA-CUSTOMIZATION.md
@@ -1,0 +1,82 @@
+# Schema Customization Without POCO Attributes
+
+All extractors and loaders accept a `JsonSerializerOptions` or `JsonTypeInfo<T>` overload, so you can fully customize JSON serialization behaviour without modifying — or even owning — the POCO class.
+
+## Naming policies
+
+Apply a naming policy to remap all property names on write and match them case-insensitively on read:
+
+```csharp
+var options = new JsonSerializerOptions
+{
+    PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    PropertyNameCaseInsensitive = true,
+};
+
+// Loader: FirstName → first_name, LastName → last_name, …
+var loader = new JsonLineLoader<Person>(stream, options);
+
+// Extractor: reads first_name → FirstName, …
+var extractor = new JsonLineExtractor<Person>(stream, options);
+```
+
+Built-in policies: `CamelCase`, `SnakeCaseLower`, `SnakeCaseUpper`, `KebabCaseLower`, `KebabCaseUpper`.
+
+## Ignoring properties
+
+Use `DefaultJsonTypeInfoResolver` modifiers to suppress individual properties at runtime:
+
+```csharp
+var options = new JsonSerializerOptions();
+options.TypeInfoResolverChain.Add(new DefaultJsonTypeInfoResolver
+{
+    Modifiers =
+    {
+        typeInfo =>
+        {
+            if (typeInfo.Type != typeof(Person)) return;
+            foreach (var prop in typeInfo.Properties)
+            {
+                if (string.Equals(prop.Name, "InternalId", StringComparison.Ordinal))
+                    prop.ShouldSerialize = (_, _) => false;
+            }
+        }
+    }
+});
+
+var loader = new JsonLineLoader<Person>(stream, options);
+```
+
+> **TFM note:** `DefaultJsonTypeInfoResolver` modifiers require .NET 8 or later. For earlier TFMs use `[JsonIgnore]` on the POCO or a custom `JsonConverter<T>`.
+
+## Custom converters
+
+Register a converter for a specific type without touching the POCO:
+
+```csharp
+var options = new JsonSerializerOptions
+{
+    Converters = { new UnixEpochDateTimeConverter() }
+};
+
+var extractor = new JsonLineExtractor<Event>(stream, options);
+```
+
+## Source-generated type metadata (AOT-safe)
+
+Pass a `JsonTypeInfo<T>` directly for reflection-free, AOT-compatible serialization:
+
+```csharp
+[JsonSerializable(typeof(Person))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+partial class PersonContext : JsonSerializerContext { }
+
+var extractor = new JsonSingleStreamExtractor<Person>(stream, PersonContext.Default.Person);
+var loader    = new JsonLineLoader<Person>(stream, PersonContext.Default.Person);
+```
+
+Source-generated contexts resolve naming, ignores, and converters at compile time — no runtime reflection is used.
+
+## Runnable example
+
+See `examples/Wolfgang.Etl.Json.Examples/Program.cs` — `SchemaCustomizationExample()` for a complete demo of snake_case naming and property suppression via `DefaultJsonTypeInfoResolver`.

--- a/examples/Wolfgang.Etl.Json.Examples/Program.cs
+++ b/examples/Wolfgang.Etl.Json.Examples/Program.cs
@@ -257,23 +257,15 @@ static async Task SkipAndMaxExample()
 
 
 
-<<<<<<< HEAD
 static async Task CompressedStreamsExample()
 {
     Console.WriteLine("=== Compressed Streams Example ===");
     Console.WriteLine("The extractors and loaders accept any Stream, including compression wrappers.");
-=======
-static async Task SchemaCustomizationExample()
-{
-    Console.WriteLine("=== Schema Customization Example ===");
-    Console.WriteLine("Customize JSON serialization without modifying the POCO class.");
->>>>>>> a4a7f83 (docs: add schema customization examples and guide (#18))
     Console.WriteLine();
 
     var people = new List<Person>
     {
         new() { FirstName = "Alice", LastName = "Smith", Age = 30, Email = "alice@example.com" },
-<<<<<<< HEAD
         new() { FirstName = "Bob", LastName = "Jones", Age = 25, Email = "bob@example.com" },
     };
 
@@ -298,7 +290,19 @@ static async Task SchemaCustomizationExample()
     }
 
     Console.WriteLine($"Extracted: {extractor.CurrentItemCount}");
-=======
+}
+
+
+
+static async Task SchemaCustomizationExample()
+{
+    Console.WriteLine("=== Schema Customization Example ===");
+    Console.WriteLine("Customize JSON serialization without modifying the POCO class.");
+    Console.WriteLine();
+
+    var people = new List<Person>
+    {
+        new() { FirstName = "Alice", LastName = "Smith", Age = 30, Email = "alice@example.com" },
     };
 
     // --- snake_case naming policy ---
@@ -343,5 +347,4 @@ static async Task SchemaCustomizationExample()
     ignoreStream.Position = 0;
     using var ignoreReader = new StreamReader(ignoreStream);
     Console.WriteLine("  " + await ignoreReader.ReadToEndAsync());
->>>>>>> a4a7f83 (docs: add schema customization examples and guide (#18))
 }

--- a/examples/Wolfgang.Etl.Json.Examples/Program.cs
+++ b/examples/Wolfgang.Etl.Json.Examples/Program.cs
@@ -30,6 +30,8 @@ Console.WriteLine();
 await SkipAndMaxExample();
 Console.WriteLine();
 await CompressedStreamsExample();
+Console.WriteLine();
+await SchemaCustomizationExample();
 
 
 
@@ -255,15 +257,23 @@ static async Task SkipAndMaxExample()
 
 
 
+<<<<<<< HEAD
 static async Task CompressedStreamsExample()
 {
     Console.WriteLine("=== Compressed Streams Example ===");
     Console.WriteLine("The extractors and loaders accept any Stream, including compression wrappers.");
+=======
+static async Task SchemaCustomizationExample()
+{
+    Console.WriteLine("=== Schema Customization Example ===");
+    Console.WriteLine("Customize JSON serialization without modifying the POCO class.");
+>>>>>>> a4a7f83 (docs: add schema customization examples and guide (#18))
     Console.WriteLine();
 
     var people = new List<Person>
     {
         new() { FirstName = "Alice", LastName = "Smith", Age = 30, Email = "alice@example.com" },
+<<<<<<< HEAD
         new() { FirstName = "Bob", LastName = "Jones", Age = 25, Email = "bob@example.com" },
     };
 
@@ -288,4 +298,50 @@ static async Task CompressedStreamsExample()
     }
 
     Console.WriteLine($"Extracted: {extractor.CurrentItemCount}");
+=======
+    };
+
+    // --- snake_case naming policy ---
+    Console.WriteLine("snake_case naming policy:");
+    var snakeOptions = new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    var snakeStream = new MemoryStream();
+    var snakeLoader = new JsonLineLoader<Person>(snakeStream, snakeOptions);
+    await snakeLoader.LoadAsync(people.ToAsyncEnumerable());
+
+    snakeStream.Position = 0;
+    using var snakeReader = new StreamReader(snakeStream);
+    Console.WriteLine("  " + await snakeReader.ReadToEndAsync());
+
+    // --- Ignore a property via JsonSerializerOptions ---
+    Console.WriteLine("Ignore Email via options:");
+    var ignoreOptions = new JsonSerializerOptions();
+    ignoreOptions.TypeInfoResolverChain.Add(new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver
+    {
+        Modifiers =
+        {
+            typeInfo =>
+            {
+                if (typeInfo.Type != typeof(Person)) return;
+                foreach (var prop in typeInfo.Properties)
+                {
+                    if (string.Equals(prop.Name, "Email", StringComparison.Ordinal))
+                        prop.ShouldSerialize = (_, _) => false;
+                }
+            }
+        }
+    });
+
+    var ignoreStream = new MemoryStream();
+    var ignoreLoader = new JsonLineLoader<Person>(ignoreStream, ignoreOptions);
+    await ignoreLoader.LoadAsync(people.ToAsyncEnumerable());
+
+    ignoreStream.Position = 0;
+    using var ignoreReader = new StreamReader(ignoreStream);
+    Console.WriteLine("  " + await ignoreReader.ReadToEndAsync());
+>>>>>>> a4a7f83 (docs: add schema customization examples and guide (#18))
 }


### PR DESCRIPTION
## Summary

Closes #18

- `docs/SCHEMA-CUSTOMIZATION.md` — guide covering naming policies, property suppression via `DefaultJsonTypeInfoResolver` modifiers, custom converters, and source-generated `JsonTypeInfo<T>` (AOT-safe). Includes TFM notes (modifiers require .NET 8+).
- `examples/Wolfgang.Etl.Json.Examples/Program.cs` — `SchemaCustomizationExample()`: demonstrates snake_case naming policy and ignoring `Email` property at runtime via `DefaultJsonTypeInfoResolver`.

No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)