### PR TITLE
docs: README Advanced Usage section (compressed streams + schema customization)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,22 @@ docfx build --serve
 
 ---
 
+## 🔧 Advanced Usage
+
+### Compressed streams
+
+All extractors and loaders accept any `Stream`, including compression wrappers — no special API is needed. Wrap the underlying stream in a `GZipStream`, `BrotliStream`, or `DeflateStream` and pass it to the constructor.
+
+See [`docs/COMPRESSED-STREAMS.md`](docs/COMPRESSED-STREAMS.md) for examples and a TFM compatibility table.
+
+### Schema customization
+
+Customize JSON serialization without modifying — or even owning — the POCO class: use naming policies, `DefaultJsonTypeInfoResolver` modifiers (.NET 8+), custom converters, or source-generated `JsonTypeInfo<T>` for AOT-safe serialization.
+
+See [`docs/SCHEMA-CUSTOMIZATION.md`](docs/SCHEMA-CUSTOMIZATION.md) for recipes.
+
+---
+
 ## 🔍 Verify the Build
 
 The NuGet packages published from this repository are reproducible and


### PR DESCRIPTION
## Summary

- Adds an **Advanced Usage** section to `README.md` between Building from Source and Verify the Build
- Two subsections: **Compressed streams** and **Schema customization**, each with a short description and a link to the relevant docs page

Closes #17
Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)