### PR TITLE
feat: OpenTelemetry metrics via System.Diagnostics.Metrics

### DIFF
--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -37,6 +38,9 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSONL extraction of {typeof(TRecord).Name}";
+    private static readonly KeyValuePair<string, object?> _operationTag = new("etl.operation", "extract");
+    private static readonly KeyValuePair<string, object?> _componentTag = new("etl.component", "JsonLine");
+    private static readonly KeyValuePair<string, object?> _recordTypeTag = new("etl.record_type", typeof(TRecord).Name);
     private readonly Stream _stream;
     private readonly JsonSerializerOptions? _options;
     private readonly JsonTypeInfo<TRecord>? _typeInfo;
@@ -270,6 +274,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
         JsonLogMessages.StartingOperation(_logger, OperationName, null);
         var (newlineSize, lineEncoding) = await PrepareForExtractionAsync(token).ConfigureAwait(false);
         var skipBudget = SkipItemCount;
+        var sw = Stopwatch.StartNew();
         using var reader = CreateStreamReader();
         string? line;
 #if NETSTANDARD2_0 || NET462 || NET481
@@ -304,6 +309,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
                 skipBudget--;
                 Interlocked.Add(ref _currentByteOffset, lineBytes);
                 IncrementCurrentSkippedItemCount();
+                JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.SkippedItemAtLine(_logger, CurrentSkippedItemCount, SkipItemCount, lineNum, null);
                 continue;
             }
@@ -314,16 +320,25 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
             }
             Interlocked.Add(ref _currentByteOffset, lineBytes);
             IncrementCurrentItemCount();
+            JsonMetrics.ItemsExtracted.Add(1, _operationTag, _componentTag, _recordTypeTag);
             JsonLogMessages.ExtractedItemFromLine(_logger, CurrentItemCount, lineNum, null);
             yield return item;
         }
 
+        CompleteExtraction(sw);
+    }
+
+
+
+    private void CompleteExtraction(Stopwatch sw)
+    {
         if (_stream.CanSeek && Interlocked.Read(ref _currentByteOffset) > _stream.Length)
         {
             Interlocked.Exchange(ref _currentByteOffset, _stream.Length);
         }
 
         JsonLogMessages.JsonlExtractionCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, Interlocked.Read(ref _currentLineNumber), null);
+        JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
     }
 
 

--- a/src/Wolfgang.Etl.Json/JsonLineLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineLoader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.Json;
@@ -32,6 +33,9 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>, I
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSONL loading of {typeof(TRecord).Name}";
+    private static readonly KeyValuePair<string, object?> _operationTag = new("etl.operation", "load");
+    private static readonly KeyValuePair<string, object?> _componentTag = new("etl.component", "JsonLine");
+    private static readonly KeyValuePair<string, object?> _recordTypeTag = new("etl.record_type", typeof(TRecord).Name);
     private static readonly byte[] _newLineUtf8 = System.Text.Encoding.UTF8.GetBytes(Environment.NewLine);
     private readonly Stream _stream;
     private readonly JsonSerializerOptions? _options;
@@ -223,6 +227,7 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>, I
         JsonLogMessages.StartingOperation(_logger, OperationName, null);
 
         var newLine = Encoding is null ? _newLineUtf8 : Encoding.GetBytes(Environment.NewLine);
+        var sw = Stopwatch.StartNew();
 
         await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
         {
@@ -231,6 +236,7 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>, I
             if (CurrentSkippedItemCount < SkipItemCount)
             {
                 IncrementCurrentSkippedItemCount();
+                JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
                 continue;
             }
@@ -266,10 +272,12 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>, I
             }
 
             IncrementCurrentItemCount();
+            JsonMetrics.ItemsLoaded.Add(1, _operationTag, _componentTag, _recordTypeTag);
             JsonLogMessages.LoadedItemAtLine(_logger, CurrentItemCount, Interlocked.Read(ref _currentLineNumber), null);
         }
 
         JsonLogMessages.JsonlLoadingCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, Interlocked.Read(ref _currentLineNumber), null);
+        JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
     }
 
 

--- a/src/Wolfgang.Etl.Json/JsonMetrics.cs
+++ b/src/Wolfgang.Etl.Json/JsonMetrics.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
+namespace Wolfgang.Etl.Json;
+
+internal static class JsonMetrics
+{
+    internal static readonly Meter Meter = new("Wolfgang.Etl.Json");
+
+
+    internal static readonly Counter<long> ItemsExtracted =
+        Meter.CreateCounter<long>(
+            "wolfgang.etl.json.items.extracted",
+            unit: null,
+            description: "Total items successfully extracted.");
+
+
+    internal static readonly Counter<long> ItemsLoaded =
+        Meter.CreateCounter<long>(
+            "wolfgang.etl.json.items.loaded",
+            unit: null,
+            description: "Total items successfully loaded.");
+
+
+    internal static readonly Counter<long> ItemsSkipped =
+        Meter.CreateCounter<long>(
+            "wolfgang.etl.json.items.skipped",
+            unit: null,
+            description: "Total items skipped via SkipItemCount.");
+
+
+    internal static readonly Histogram<double> OperationDuration =
+        Meter.CreateHistogram<double>(
+            "wolfgang.etl.json.operation.duration",
+            unit: "ms",
+            description: "Duration of extract/load operations in milliseconds.");
+}

--- a/src/Wolfgang.Etl.Json/JsonMultiStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonMultiStreamExtractor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -40,6 +41,9 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSON multi-stream extraction of {typeof(TRecord).Name}";
+    private static readonly KeyValuePair<string, object?> _operationTag = new("etl.operation", "extract");
+    private static readonly KeyValuePair<string, object?> _componentTag = new("etl.component", "JsonMultiStream");
+    private static readonly KeyValuePair<string, object?> _recordTypeTag = new("etl.record_type", typeof(TRecord).Name);
     private readonly IEnumerable<JsonNamedStream> _sources;
     private readonly JsonSerializerOptions? _options;
     private readonly JsonTypeInfo<TRecord>? _typeInfo;
@@ -383,44 +387,54 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
 
         var skipBudget = SkipItemCount;
         var streamIndex = 0;
+        var sw = Stopwatch.StartNew();
 
-        foreach (var source in _sources)
+        try
         {
-            token.ThrowIfCancellationRequested();
-            _currentSourceName = source.Name;
-            JsonLogMessages.ReadingStream(_logger, streamIndex, null);
-
-            var (item, failed) = await TryDeserializeStreamAsync(source.Stream, streamIndex, token).ConfigureAwait(false);
-            streamIndex++;
-            if (failed) { continue; }
-
-            if (item is null)
+            foreach (var source in _sources)
             {
-                JsonLogMessages.StreamDeserializedToNull(_logger, streamIndex - 1, null);
-                continue;
+                token.ThrowIfCancellationRequested();
+                _currentSourceName = source.Name;
+                JsonLogMessages.ReadingStream(_logger, streamIndex, null);
+
+                var (item, failed) = await TryDeserializeStreamAsync(source.Stream, streamIndex, token).ConfigureAwait(false);
+                streamIndex++;
+                if (failed) { continue; }
+
+                if (item is null)
+                {
+                    JsonLogMessages.StreamDeserializedToNull(_logger, streamIndex - 1, null);
+                    continue;
+                }
+
+                if (skipBudget > 0)
+                {
+                    skipBudget--;
+                    IncrementCurrentSkippedItemCount();
+                    JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                    JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
+                    continue;
+                }
+
+                if (CurrentItemCount >= MaximumItemCount)
+                {
+                    JsonLogMessages.ReachedMaximumItemCount(_logger, MaximumItemCount, null);
+                    break;
+                }
+
+                IncrementCurrentItemCount();
+                JsonMetrics.ItemsExtracted.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                JsonLogMessages.ExtractedItemFromStream(_logger, CurrentItemCount, streamIndex - 1, null);
+
+                yield return item;
             }
 
-            if (skipBudget > 0)
-            {
-                skipBudget--;
-                IncrementCurrentSkippedItemCount();
-                JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
-                continue;
-            }
-
-            if (CurrentItemCount >= MaximumItemCount)
-            {
-                JsonLogMessages.ReachedMaximumItemCount(_logger, MaximumItemCount, null);
-                break;
-            }
-
-            IncrementCurrentItemCount();
-            JsonLogMessages.ExtractedItemFromStream(_logger, CurrentItemCount, streamIndex - 1, null);
-
-            yield return item;
+            JsonLogMessages.MultiStreamExtractionCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, streamIndex, null);
         }
-
-        JsonLogMessages.MultiStreamExtractionCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, streamIndex, null);
+        finally
+        {
+            JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
+        }
     }
 
 

--- a/src/Wolfgang.Etl.Json/JsonMultiStreamLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonMultiStreamLoader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.Json;
@@ -36,6 +37,9 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSON multi-stream loading of {typeof(TRecord).Name}";
+    private static readonly KeyValuePair<string, object?> _operationTag = new("etl.operation", "load");
+    private static readonly KeyValuePair<string, object?> _componentTag = new("etl.component", "JsonMultiStream");
+    private static readonly KeyValuePair<string, object?> _recordTypeTag = new("etl.record_type", typeof(TRecord).Name);
     private readonly Func<TRecord, JsonNamedDestination> _destinationFactory;
     private readonly JsonSerializerOptions? _options;
     private readonly JsonTypeInfo<TRecord>? _typeInfo;
@@ -394,47 +398,58 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
         JsonLogMessages.StartingOperation(_logger, OperationName, null);
 
         var streamIndex = 0;
+        var sw = Stopwatch.StartNew();
 
-        await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
+        try
         {
-            token.ThrowIfCancellationRequested();
-
-            if (CurrentSkippedItemCount < SkipItemCount)
+            await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
             {
-                IncrementCurrentSkippedItemCount();
-                JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
-                continue;
-            }
+                token.ThrowIfCancellationRequested();
 
-            if (CurrentItemCount >= MaximumItemCount)
-            {
-                JsonLogMessages.ReachedMaximumItemCount(_logger, MaximumItemCount, null);
-                break;
-            }
+                if (CurrentSkippedItemCount < SkipItemCount)
+                {
+                    IncrementCurrentSkippedItemCount();
+                    JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                    JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
+                    continue;
+                }
 
-            if (IsDryRun)
-            {
-                _currentDestinationName = null;
+                if (CurrentItemCount >= MaximumItemCount)
+                {
+                    JsonLogMessages.ReachedMaximumItemCount(_logger, MaximumItemCount, null);
+                    break;
+                }
+
+                if (IsDryRun)
+                {
+                    _currentDestinationName = null;
+                    IncrementCurrentItemCount();
+                    JsonMetrics.ItemsLoaded.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                    streamIndex++;
+                    JsonLogMessages.LoadedItemToStream(_logger, CurrentItemCount, streamIndex - 1, null);
+                    continue;
+                }
+
+                var destination = _destinationFactory(item);
+                _currentDestinationName = destination?.Name;
+                if (destination?.Stream is null)
+                {
+                    JsonLogMessages.StreamFactoryReturnedNull(_logger, streamIndex, null);
+                    throw new InvalidOperationException($"Destination factory returned null or a null stream for item at index {streamIndex}.");
+                }
+                await WriteItemToStreamAsync(destination.Stream, item, streamIndex, token).ConfigureAwait(false);
                 IncrementCurrentItemCount();
+                JsonMetrics.ItemsLoaded.Add(1, _operationTag, _componentTag, _recordTypeTag);
                 streamIndex++;
                 JsonLogMessages.LoadedItemToStream(_logger, CurrentItemCount, streamIndex - 1, null);
-                continue;
             }
 
-            var destination = _destinationFactory(item);
-            _currentDestinationName = destination?.Name;
-            if (destination?.Stream is null)
-            {
-                JsonLogMessages.StreamFactoryReturnedNull(_logger, streamIndex, null);
-                throw new InvalidOperationException($"Destination factory returned null or a null stream for item at index {streamIndex}.");
-            }
-            await WriteItemToStreamAsync(destination.Stream, item, streamIndex, token).ConfigureAwait(false);
-            IncrementCurrentItemCount();
-            streamIndex++;
-            JsonLogMessages.LoadedItemToStream(_logger, CurrentItemCount, streamIndex - 1, null);
+            JsonLogMessages.MultiStreamLoadingCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, streamIndex, null);
         }
-
-        JsonLogMessages.MultiStreamLoadingCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, streamIndex, null);
+        finally
+        {
+            JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
+        }
     }
 
 

--- a/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -37,6 +38,9 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSON single-stream extraction of {typeof(TRecord).Name}";
+    private static readonly KeyValuePair<string, object?> _operationTag = new("etl.operation", "extract");
+    private static readonly KeyValuePair<string, object?> _componentTag = new("etl.component", "JsonSingleStream");
+    private static readonly KeyValuePair<string, object?> _recordTypeTag = new("etl.record_type", typeof(TRecord).Name);
     private static readonly JsonSerializerOptions DefaultOptions = new();
 
     private readonly Stream _stream;
@@ -234,6 +238,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
         JsonLogMessages.StartingOperation(_logger, OperationName, null);
 
         var skipBudget = SkipItemCount;
+        var sw = Stopwatch.StartNew();
         var enumerable = _typeInfo is not null
             ? JsonSerializer.DeserializeAsyncEnumerable(_stream, _typeInfo, token)
             : JsonSerializer.DeserializeAsyncEnumerable<TRecord>(_stream, _options ?? DefaultOptions, token);
@@ -262,6 +267,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
                 {
                     skipBudget--;
                     IncrementCurrentSkippedItemCount();
+                    JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
                     JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
                     continue;
                 }
@@ -271,6 +277,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
                     break;
                 }
                 IncrementCurrentItemCount();
+                JsonMetrics.ItemsExtracted.Add(1, _operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.ExtractedItem(_logger, CurrentItemCount, null);
                 yield return item;
             }
@@ -278,6 +285,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
         finally
         {
             await enumerator.DisposeAsync().ConfigureAwait(false);
+            JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
         }
 
         JsonLogMessages.SingleStreamExtractionCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, null);

--- a/src/Wolfgang.Etl.Json/JsonSingleStreamLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonSingleStreamLoader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.Json;
@@ -31,6 +32,9 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSON single-stream loading of {typeof(TRecord).Name}";
+    private static readonly KeyValuePair<string, object?> _operationTag = new("etl.operation", "load");
+    private static readonly KeyValuePair<string, object?> _componentTag = new("etl.component", "JsonSingleStream");
+    private static readonly KeyValuePair<string, object?> _recordTypeTag = new("etl.record_type", typeof(TRecord).Name);
     private readonly Stream _stream;
     private readonly JsonSerializerOptions? _options;
     private readonly JsonTypeInfo<TRecord>? _typeInfo;
@@ -211,6 +215,8 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
     {
         JsonLogMessages.StartingOperation(_logger, OperationName, null);
 
+        var sw = Stopwatch.StartNew();
+
         // CA2007/MA0004: await using declarations do not support ConfigureAwait in C#
 #pragma warning disable CA2007, MA0004
         await using var writer = IsDryRun ? null : new Utf8JsonWriter(_stream);
@@ -225,6 +231,7 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
             if (CurrentSkippedItemCount < SkipItemCount)
             {
                 IncrementCurrentSkippedItemCount();
+                JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
                 continue;
             }
@@ -248,6 +255,7 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
             }
 
             IncrementCurrentItemCount();
+            JsonMetrics.ItemsLoaded.Add(1, _operationTag, _componentTag, _recordTypeTag);
             JsonLogMessages.LoadedItem(_logger, CurrentItemCount, null);
         }
 
@@ -258,6 +266,7 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
         }
 
         JsonLogMessages.SingleStreamLoadingCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, null);
+        JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
     }
 
 

--- a/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
+++ b/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.15.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.9" />
     <PackageReference Include="System.Text.Json" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Adds `System.Diagnostics.Metrics` instrumentation to all six extractors and loaders via a new internal `JsonMetrics` class.

### Instruments (Meter name: `Wolfgang.Etl.Json`)

| Instrument | Type | Unit |
|---|---|---|
| `wolfgang.etl.json.items.extracted` | Counter | items |
| `wolfgang.etl.json.items.loaded` | Counter | items |
| `wolfgang.etl.json.items.skipped` | Counter | items |
| `wolfgang.etl.json.operation.duration` | Histogram | ms |

### Tags

All instruments tagged with:
- `etl.operation` — `extract` or `load`
- `etl.component` — `JsonLine`, `JsonSingleStream`, or `JsonMultiStream`
- `etl.record_type` — `typeof(TRecord).Name`

Tags are precomputed as `static readonly` fields — no per-call allocation. Instruments are no-op when no `MeterListener` is registered (zero overhead in the default case).

### Usage

```csharp
using var listener = new MeterListener();
listener.InstrumentPublished = (instrument, l) =>
{
    if (instrument.Meter.Name == "Wolfgang.Etl.Json")
        l.EnableMeasurementEvents(instrument);
};
listener.SetMeasurementEventCallback<long>((instr, val, tags, _) =>
    Console.WriteLine($"{instr.Name} +{val}"));
listener.Start();
```

Or wire up OpenTelemetry:
```csharp
services.AddOpenTelemetry()
    .WithMetrics(b => b.AddMeter("Wolfgang.Etl.Json"));
```

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)