### PR TITLE
feat: checkpoint/resume for JsonLineExtractor (#16)

### DIFF
--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Wolfgang.Etl.Abstractions;
@@ -43,6 +45,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
     private readonly List<JsonDeserializationError> _errors = new();
     private int _progressTimerWired;
     private long _currentLineNumber;
+    private long _currentByteOffset;
 
 
 
@@ -52,6 +55,24 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
     /// stream's byte-order mark (BOM), falling back to UTF-8.
     /// </summary>
     public System.Text.Encoding? Encoding { get; set; }
+
+
+
+    /// <summary>
+    /// Gets or sets the byte offset within the stream at which extraction begins.
+    /// Set this before calling <see cref="ExtractorBase{TSource,TProgress}.ExtractAsync(System.Threading.CancellationToken)"/> to resume from a saved checkpoint.
+    /// The stream must be seekable when this value is greater than zero.
+    /// Default is <c>0</c> (start of stream).
+    /// </summary>
+    public long StartByteOffset { get; set; }
+
+
+
+    /// <summary>
+    /// Gets the byte offset of the start of the next unread line in the stream.
+    /// Capture this value after each <see langword="yield"/> to create a resumable checkpoint.
+    /// </summary>
+    public long CurrentByteOffset => Interlocked.Read(ref _currentByteOffset);
 
 
 
@@ -246,13 +267,10 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
     )
     {
         _errors.Clear();
-        Interlocked.Exchange(ref _currentLineNumber, 0);
         JsonLogMessages.StartingOperation(_logger, OperationName, null);
-
+        var (newlineSize, lineEncoding) = await PrepareForExtractionAsync(token).ConfigureAwait(false);
         var skipBudget = SkipItemCount;
-
         using var reader = CreateStreamReader();
-
         string? line;
 #if NETSTANDARD2_0 || NET462 || NET481
         while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) is not null)
@@ -261,43 +279,93 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
 #endif
         {
             token.ThrowIfCancellationRequested();
-            Interlocked.Increment(ref _currentLineNumber);
-            var lineNum = Interlocked.Read(ref _currentLineNumber);
-
+            var lineBytes = lineEncoding.GetByteCount(line) + newlineSize;
+            var lineNum = Interlocked.Increment(ref _currentLineNumber);
             if (string.IsNullOrWhiteSpace(line))
             {
+                Interlocked.Add(ref _currentByteOffset, lineBytes);
                 JsonLogMessages.SkippingBlankLine(_logger, lineNum, null);
                 continue;
             }
-
-            if (!TryDeserializeLine(line, lineNum, out var item)) { continue; }
-            if (item is null)
-            {
-                JsonLogMessages.LineDeserializedToNull(_logger, lineNum, null);
-                continue;
-            }
-
+            if (!TryDeserializeLine(line, lineNum, out var item)) { Interlocked.Add(ref _currentByteOffset, lineBytes); continue; }
+            if (item is null) { Interlocked.Add(ref _currentByteOffset, lineBytes); JsonLogMessages.LineDeserializedToNull(_logger, lineNum, null); continue; }
             if (skipBudget > 0)
             {
                 skipBudget--;
+                Interlocked.Add(ref _currentByteOffset, lineBytes);
                 IncrementCurrentSkippedItemCount();
                 JsonLogMessages.SkippedItemAtLine(_logger, CurrentSkippedItemCount, SkipItemCount, lineNum, null);
                 continue;
             }
-
             if (CurrentItemCount >= MaximumItemCount)
             {
                 JsonLogMessages.ReachedMaximumItemCount(_logger, MaximumItemCount, null);
                 break;
             }
-
+            Interlocked.Add(ref _currentByteOffset, lineBytes);
             IncrementCurrentItemCount();
             JsonLogMessages.ExtractedItemFromLine(_logger, CurrentItemCount, lineNum, null);
-
             yield return item;
         }
 
+        if (_stream.CanSeek && Interlocked.Read(ref _currentByteOffset) > _stream.Length)
+        {
+            Interlocked.Exchange(ref _currentByteOffset, _stream.Length);
+        }
+
         JsonLogMessages.JsonlExtractionCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, Interlocked.Read(ref _currentLineNumber), null);
+    }
+
+
+
+    private async Task<(int NewlineSize, Encoding LineEncoding)> PrepareForExtractionAsync(CancellationToken token)
+    {
+        Interlocked.Exchange(ref _currentLineNumber, 0);
+        Interlocked.Exchange(ref _currentByteOffset, StartByteOffset);
+        var lineEncoding = Encoding ?? System.Text.Encoding.UTF8;
+        var newlineSize = await DetectNewlineSizeAsync(token).ConfigureAwait(false);
+        if (StartByteOffset > 0)
+        {
+            if (!_stream.CanSeek)
+            {
+                throw new InvalidOperationException
+                (
+                    "Stream must be seekable when StartByteOffset is greater than zero."
+                );
+            }
+
+            _stream.Seek(StartByteOffset, SeekOrigin.Begin);
+        }
+
+        return (newlineSize, lineEncoding);
+    }
+
+
+
+    private async Task<int> DetectNewlineSizeAsync(CancellationToken token)
+    {
+        if (!_stream.CanSeek) { return 1; }
+
+        var savedPosition = _stream.Position;
+        _stream.Seek(0, SeekOrigin.Begin);
+        var buffer = new byte[256];
+#if NETSTANDARD2_0 || NET462 || NET481
+#pragma warning disable CA2016, MA0040 // old TFM overload has no CancellationToken parameter
+        var bytesRead = await _stream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+#pragma warning restore CA2016, MA0040
+        _ = token;
+#else
+        var bytesRead = await _stream.ReadAsync(buffer.AsMemory(0, buffer.Length), token).ConfigureAwait(false);
+#endif
+        _stream.Seek(savedPosition, SeekOrigin.Begin);
+
+        for (var i = 0; i < bytesRead - 1; i++)
+        {
+            if (buffer[i] == '\r' && buffer[i + 1] == '\n') { return 2; }
+            if (buffer[i] == '\n') { return 1; }
+        }
+
+        return 1;
     }
 
 

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonLineExtractorTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonLineExtractorTests.cs
@@ -649,4 +649,135 @@ public class JsonLineExtractorTests
 
         Assert.Equal(item, results[0]);
     }
+
+
+
+    [Fact]
+    public void StartByteOffset_defaults_to_zero()
+    {
+        var sut = new JsonLineExtractor<PersonRecord>(new MemoryStream());
+        Assert.Equal(0, sut.StartByteOffset);
+    }
+
+
+
+    [Fact]
+    public void CurrentByteOffset_is_zero_before_extraction()
+    {
+        var sut = new JsonLineExtractor<PersonRecord>(new MemoryStream());
+        Assert.Equal(0, sut.CurrentByteOffset);
+    }
+
+
+
+    [Fact]
+    public async Task CurrentByteOffset_advances_to_stream_length_after_full_extraction()
+    {
+        var stream = CreateJsonlStream(3);
+        var sut = new JsonLineExtractor<PersonRecord>(stream);
+
+        await sut.ExtractAsync().ToListAsync();
+
+        Assert.Equal(stream.Length, sut.CurrentByteOffset);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_StartByteOffset_set_resumes_from_checkpoint()
+    {
+        var stream = CreateJsonlStream(ExpectedItems.Count);
+
+        // First pass — extract the first two items and capture the checkpoint.
+        var sut1 = new JsonLineExtractor<PersonRecord>(stream)
+        {
+            MaximumItemCount = 2,
+        };
+        var firstBatch = await sut1.ExtractAsync().ToListAsync();
+        var checkpoint = sut1.CurrentByteOffset;
+
+        // Second pass — seek to checkpoint and extract the remainder.
+        var sut2 = new JsonLineExtractor<PersonRecord>(stream)
+        {
+            StartByteOffset = checkpoint,
+        };
+        var secondBatch = await sut2.ExtractAsync().ToListAsync();
+
+        Assert.Equal(ExpectedItems.Take(2).ToList(), firstBatch);
+        Assert.Equal(ExpectedItems.Skip(2).ToList(), secondBatch);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_StartByteOffset_set_extracts_items_from_checkpoint()
+    {
+        var stream = CreateJsonlStream(3);
+        var sut1 = new JsonLineExtractor<PersonRecord>(stream) { MaximumItemCount = 1 };
+        await sut1.ExtractAsync().ToListAsync();
+        var checkpoint = sut1.CurrentByteOffset;
+
+        var sut2 = new JsonLineExtractor<PersonRecord>(stream) { StartByteOffset = checkpoint };
+        var results = await sut2.ExtractAsync().ToListAsync();
+
+        Assert.Equal(ExpectedItems.Skip(1).Take(2).ToList(), results);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_StartByteOffset_non_zero_and_stream_not_seekable_throws()
+    {
+        using var ms = CreateJsonlStream(3);
+        using var nonSeekable = new NonSeekableStream(ms);
+        var sut = new JsonLineExtractor<PersonRecord>(nonSeekable)
+        {
+            StartByteOffset = 10,
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () => await sut.ExtractAsync().ToListAsync()
+        );
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_with_crlf_stream_CurrentByteOffset_advances_to_stream_length()
+    {
+        var lines = ExpectedItems.Take(3).Select(item => JsonSerializer.Serialize(item));
+        var content = string.Join("\r\n", lines);
+        var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+        var sut = new JsonLineExtractor<PersonRecord>(stream);
+
+        await sut.ExtractAsync().ToListAsync();
+
+        Assert.Equal(stream.Length, sut.CurrentByteOffset);
+    }
+
+
+
+    private sealed class NonSeekableStream : Stream
+    {
+        private readonly Stream _inner;
+
+        internal NonSeekableStream(Stream inner) => _inner = inner;
+
+        public override bool CanRead => _inner.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => _inner.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `StartByteOffset` (`long`, settable) — set before `ExtractAsync` to seek to a saved checkpoint; requires a seekable stream when non-zero
- Adds `CurrentByteOffset` (`long`, read-only) — byte offset of the next unread line; capture after each yielded item to create a durable checkpoint
- Advances the offset only for permanently-consumed lines (blank, error, null, SkipItemCount skips, yielded items); NOT for MaximumItemCount breaks — so resuming replays those items correctly
- Clamps to `stream.Length` after natural exhaustion to handle JSONL files without trailing newlines
- Detects CRLF vs LF line endings via a 256-byte probe at stream start

## Test plan

- [ ] `StartByteOffset_defaults_to_zero`
- [ ] `CurrentByteOffset_is_zero_before_extraction`
- [ ] `CurrentByteOffset_advances_to_stream_length_after_full_extraction`
- [ ] `ExtractAsync_when_StartByteOffset_set_resumes_from_checkpoint`
- [ ] `ExtractAsync_when_StartByteOffset_set_extracts_items_from_checkpoint`
- [ ] `ExtractAsync_when_StartByteOffset_non_zero_and_stream_not_seekable_throws`
- [ ] `ExtractAsync_with_crlf_stream_CurrentByteOffset_advances_to_stream_length`

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)