### PR TITLE
style: expand one-liner branches to Allman style (follow-up to #238)

### DIFF
--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -287,8 +287,18 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
                 JsonLogMessages.SkippingBlankLine(_logger, lineNum, null);
                 continue;
             }
-            if (!TryDeserializeLine(line, lineNum, out var item)) { Interlocked.Add(ref _currentByteOffset, lineBytes); continue; }
-            if (item is null) { Interlocked.Add(ref _currentByteOffset, lineBytes); JsonLogMessages.LineDeserializedToNull(_logger, lineNum, null); continue; }
+            if (!TryDeserializeLine(line, lineNum, out var item))
+            {
+                Interlocked.Add(ref _currentByteOffset, lineBytes);
+                continue;
+            }
+
+            if (item is null)
+            {
+                Interlocked.Add(ref _currentByteOffset, lineBytes);
+                JsonLogMessages.LineDeserializedToNull(_logger, lineNum, null);
+                continue;
+            }
             if (skipBudget > 0)
             {
                 skipBudget--;


### PR DESCRIPTION
## Summary

- Expands two inline `{ ... continue; }` branches in `ExtractWorkerAsync` to Allman-style blocks, per review comment on #238

## Test plan

- [ ] Existing 432 unit tests pass (no behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)