### PR TITLE
release: bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-18
+
+### Added
+
+- Checkpoint/resume support on `JsonLineExtractor<TRecord>`: new `StartByteOffset` (settable) and
+  `CurrentByteOffset` (read-only) properties. Capture `CurrentByteOffset` after each yielded item to
+  record a byte-position checkpoint, then set `StartByteOffset` on a fresh extractor to resume from
+  that position. The stream must be seekable when `StartByteOffset` is greater than zero. Line
+  endings (`\n` vs `\r\n`) are detected automatically. Closes #16.
+- Built-in OpenTelemetry metrics via `System.Diagnostics.Metrics`. All extractors and loaders emit
+  counters (`wolfgang.etl.json.items.extracted`, `.items.loaded`, `.items.skipped`) and an operation
+  duration histogram (`wolfgang.etl.json.operation.duration`) under the `Wolfgang.Etl.Json` meter,
+  tagged with `etl.operation`, `etl.component`, and `etl.record_type`. Closes #14.
+
+## [0.4.0] - 2026-07-15
+
+### Changed
+
+- `JsonLineLoader<TRecord>` now writes directly to the output stream instead of wrapping it in a
+  `StreamWriter`, avoiding an unnecessary buffering layer.
+
+### Fixed
+
+- Suppressed the UTF-8 byte-order mark (BOM) emitted by `JsonLineLoader<TRecord>` on older target
+  frameworks so JSONL output is byte-identical across all TFMs.
+
 ## [0.3.0] - 2026-07-13
 
 ### Added
@@ -104,7 +130,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cached the default `JsonSerializerOptions` and log operation-name strings as
   static fields; sealed the extractor and loader classes.
 
-[Unreleased]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.2.0...v0.2.1

--- a/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
+++ b/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +


### PR DESCRIPTION
## Summary

Version bump for the v0.5.0 release. `vNext` already carries the two feature merges; this PR just sets the version and documents the release.

- `<Version>` 0.4.0 → 0.5.0 (MINOR — two additive public-API features, no breaking changes)
- CHANGELOG: new `[0.5.0]` entry (checkpoint/resume #16, OpenTelemetry metrics #14)
- CHANGELOG: backfilled the missing `[0.4.0]` entry (StreamWriter removal, BOM suppression) and fixed the stale compare-link footer

## What ships in 0.5.0

| Feature | Issue | PR |
|---|---|---|
| Checkpoint/resume for `JsonLineExtractor` (`StartByteOffset` / `CurrentByteOffset`) | #16 | #238 |
| OpenTelemetry metrics across all extractors/loaders | #14 | #237 |

## Test plan

- [x] `dotnet test -c Release` green across all TFMs (432 unit + 12 integration per TFM)
- [ ] CI Stage 1/2/3 green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)