### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Checkpoint/resume support on `JsonLineExtractor<TRecord>`: new `StartByteOffset` (settable) and
-  `CurrentByteOffset` (read-only) properties. Capture `CurrentByteOffset` after each yielded item to
-  record a byte-position checkpoint, then set `StartByteOffset` on a fresh extractor to resume from
-  that position. The stream must be seekable when `StartByteOffset` is greater than zero. Line
-  endings (`\n` vs `\r\n`) are detected automatically. Closes #16.
+- Checkpoint/resume support on `JsonLineExtractor<TRecord>`: new `EnableCheckpointing` (settable,
+  default `false`), `StartByteOffset` (settable) and `CurrentByteOffset` (read-only) properties. Set
+  `EnableCheckpointing` to `true`, then capture `CurrentByteOffset` after each yielded item to record
+  a byte-position checkpoint; set `StartByteOffset` on a fresh extractor to resume from that position.
+  Byte tracking is opt-in because it adds per-line overhead on the extraction hot path — with
+  `EnableCheckpointing` left `false` (the default) there is no cost, and reading `CurrentByteOffset`
+  throws `InvalidOperationException`. Resuming via `StartByteOffset` does not itself require the flag.
+  The stream must be seekable when `StartByteOffset` is greater than zero. Line endings (`\n` vs
+  `\r\n`) are detected automatically. Closes #16.
 - Built-in OpenTelemetry metrics via `System.Diagnostics.Metrics`. All extractors and loaders emit
   counters (`wolfgang.etl.json.items.extracted`, `.items.loaded`, `.items.skipped`) and an operation
   duration histogram (`wolfgang.etl.json.operation.duration`) under the `Wolfgang.Etl.Json` meter,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-18
+
+### Added
+
+- Checkpoint/resume support on `JsonLineExtractor<TRecord>`: new `StartByteOffset` (settable) and
+  `CurrentByteOffset` (read-only) properties. Capture `CurrentByteOffset` after each yielded item to
+  record a byte-position checkpoint, then set `StartByteOffset` on a fresh extractor to resume from
+  that position. The stream must be seekable when `StartByteOffset` is greater than zero. Line
+  endings (`\n` vs `\r\n`) are detected automatically. Closes #16.
+- Built-in OpenTelemetry metrics via `System.Diagnostics.Metrics`. All extractors and loaders emit
+  counters (`wolfgang.etl.json.items.extracted`, `.items.loaded`, `.items.skipped`) and an operation
+  duration histogram (`wolfgang.etl.json.operation.duration`) under the `Wolfgang.Etl.Json` meter,
+  tagged with `etl.operation`, `etl.component`, and `etl.record_type`. Closes #14.
+
+## [0.4.0] - 2026-07-15
+
+### Changed
+
+- `JsonLineLoader<TRecord>` now writes directly to the output stream instead of wrapping it in a
+  `StreamWriter`, avoiding an unnecessary buffering layer.
+
+### Fixed
+
+- Suppressed the UTF-8 byte-order mark (BOM) emitted by `JsonLineLoader<TRecord>` on older target
+  frameworks so JSONL output is byte-identical across all TFMs.
+
 ## [0.3.0] - 2026-07-13
 
 ### Added
@@ -104,7 +130,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cached the default `JsonSerializerOptions` and log operation-name strings as
   static fields; sealed the extractor and loader classes.
 
-[Unreleased]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Chris-Wolfgang/ETL-Json/compare/v0.2.0...v0.2.1

--- a/README.md
+++ b/README.md
@@ -236,6 +236,22 @@ docfx build --serve
 
 ---
 
+## 🔧 Advanced Usage
+
+### Compressed streams
+
+All extractors and loaders accept any `Stream`, including compression wrappers — no special API is needed. Wrap the underlying stream in a `GZipStream`, `BrotliStream`, or `DeflateStream` and pass it to the constructor.
+
+See [`docs/COMPRESSED-STREAMS.md`](docs/COMPRESSED-STREAMS.md) for examples and a TFM compatibility table.
+
+### Schema customization
+
+Customize JSON serialization without modifying — or even owning — the POCO class: use naming policies, `DefaultJsonTypeInfoResolver` modifiers (.NET 8+), custom converters, or source-generated `JsonTypeInfo<T>` for AOT-safe serialization.
+
+See [`docs/SCHEMA-CUSTOMIZATION.md`](docs/SCHEMA-CUSTOMIZATION.md) for recipes.
+
+---
+
 ## 🔍 Verify the Build
 
 The NuGet packages published from this repository are reproducible and

--- a/docs/COMPRESSED-STREAMS.md
+++ b/docs/COMPRESSED-STREAMS.md
@@ -1,0 +1,57 @@
+# Compressed Streams
+
+All extractors and loaders in `Wolfgang.Etl.Json` accept any `Stream` — including compression wrappers from `System.IO.Compression`. No special API is needed: wrap the underlying stream in a `GZipStream`, `BrotliStream`, or `DeflateStream` before passing it to the constructor.
+
+## Load to GZip-compressed JSONL
+
+```csharp
+using var fileStream = File.Create("output.jsonl.gz");
+using var gzipStream = new GZipStream(fileStream, CompressionLevel.Optimal, leaveOpen: true);
+var loader = new JsonLineLoader<Record>(gzipStream);
+await loader.LoadAsync(records);
+```
+
+> **Note:** Pass `leaveOpen: true` to `GZipStream` when the underlying stream is owned by the caller. `GZipStream` disposes the inner stream on its own dispose unless `leaveOpen` is set.
+
+## Extract from GZip-compressed JSONL
+
+```csharp
+using var fileStream = File.OpenRead("data.jsonl.gz");
+using var gzipStream = new GZipStream(fileStream, CompressionMode.Decompress);
+var extractor = new JsonLineExtractor<Record>(gzipStream);
+
+await foreach (var item in extractor.ExtractAsync())
+{
+    Console.WriteLine(item);
+}
+```
+
+## Extract from GZip-compressed JSON array
+
+```csharp
+using var fileStream = File.OpenRead("data.json.gz");
+using var gzipStream = new GZipStream(fileStream, CompressionMode.Decompress);
+var extractor = new JsonSingleStreamExtractor<Record>(gzipStream);
+```
+
+## Brotli variant
+
+```csharp
+using var fileStream = File.OpenRead("data.jsonl.br");
+using var brotliStream = new BrotliStream(fileStream, CompressionMode.Decompress);
+var extractor = new JsonLineExtractor<Record>(brotliStream);
+```
+
+> **Note:** `BrotliStream` requires .NET Core 2.1 or later (`netcoreapp2.1` / `netstandard2.1` / `net5.0+`). It is not available on .NET Framework.
+
+## Choosing a compression format
+
+| Format | Class | Extension | Notes |
+|---|---|---|---|
+| GZip | `GZipStream` | `.gz` | Available on all TFMs including .NET Framework |
+| Brotli | `BrotliStream` | `.br` | .NET Core 2.1+ only; best compression ratio |
+| Deflate | `DeflateStream` | `.deflate` | Available on all TFMs; GZip is usually preferred |
+
+## Runnable example
+
+See `examples/Wolfgang.Etl.Json.Examples/Program.cs` — `CompressedStreamsExample()` for a complete load-then-extract round-trip using GZip.

--- a/docs/SCHEMA-CUSTOMIZATION.md
+++ b/docs/SCHEMA-CUSTOMIZATION.md
@@ -1,0 +1,82 @@
+# Schema Customization Without POCO Attributes
+
+All extractors and loaders accept a `JsonSerializerOptions` or `JsonTypeInfo<T>` overload, so you can fully customize JSON serialization behaviour without modifying — or even owning — the POCO class.
+
+## Naming policies
+
+Apply a naming policy to remap all property names on write and match them case-insensitively on read:
+
+```csharp
+var options = new JsonSerializerOptions
+{
+    PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    PropertyNameCaseInsensitive = true,
+};
+
+// Loader: FirstName → first_name, LastName → last_name, …
+var loader = new JsonLineLoader<Person>(stream, options);
+
+// Extractor: reads first_name → FirstName, …
+var extractor = new JsonLineExtractor<Person>(stream, options);
+```
+
+Built-in policies: `CamelCase`, `SnakeCaseLower`, `SnakeCaseUpper`, `KebabCaseLower`, `KebabCaseUpper`.
+
+## Ignoring properties
+
+Use `DefaultJsonTypeInfoResolver` modifiers to suppress individual properties at runtime:
+
+```csharp
+var options = new JsonSerializerOptions();
+options.TypeInfoResolverChain.Add(new DefaultJsonTypeInfoResolver
+{
+    Modifiers =
+    {
+        typeInfo =>
+        {
+            if (typeInfo.Type != typeof(Person)) return;
+            foreach (var prop in typeInfo.Properties)
+            {
+                if (string.Equals(prop.Name, "InternalId", StringComparison.Ordinal))
+                    prop.ShouldSerialize = (_, _) => false;
+            }
+        }
+    }
+});
+
+var loader = new JsonLineLoader<Person>(stream, options);
+```
+
+> **TFM note:** `DefaultJsonTypeInfoResolver` modifiers require .NET 8 or later. For earlier TFMs use `[JsonIgnore]` on the POCO or a custom `JsonConverter<T>`.
+
+## Custom converters
+
+Register a converter for a specific type without touching the POCO:
+
+```csharp
+var options = new JsonSerializerOptions
+{
+    Converters = { new UnixEpochDateTimeConverter() }
+};
+
+var extractor = new JsonLineExtractor<Event>(stream, options);
+```
+
+## Source-generated type metadata (AOT-safe)
+
+Pass a `JsonTypeInfo<T>` directly for reflection-free, AOT-compatible serialization:
+
+```csharp
+[JsonSerializable(typeof(Person))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+partial class PersonContext : JsonSerializerContext { }
+
+var extractor = new JsonSingleStreamExtractor<Person>(stream, PersonContext.Default.Person);
+var loader    = new JsonLineLoader<Person>(stream, PersonContext.Default.Person);
+```
+
+Source-generated contexts resolve naming, ignores, and converters at compile time — no runtime reflection is used.
+
+## Runnable example
+
+See `examples/Wolfgang.Etl.Json.Examples/Program.cs` — `SchemaCustomizationExample()` for a complete demo of snake_case naming and property suppression via `DefaultJsonTypeInfoResolver`.

--- a/examples/Wolfgang.Etl.Json.Examples/Program.cs
+++ b/examples/Wolfgang.Etl.Json.Examples/Program.cs
@@ -257,23 +257,15 @@ static async Task SkipAndMaxExample()
 
 
 
-<<<<<<< HEAD
 static async Task CompressedStreamsExample()
 {
     Console.WriteLine("=== Compressed Streams Example ===");
     Console.WriteLine("The extractors and loaders accept any Stream, including compression wrappers.");
-=======
-static async Task SchemaCustomizationExample()
-{
-    Console.WriteLine("=== Schema Customization Example ===");
-    Console.WriteLine("Customize JSON serialization without modifying the POCO class.");
->>>>>>> a4a7f83 (docs: add schema customization examples and guide (#18))
     Console.WriteLine();
 
     var people = new List<Person>
     {
         new() { FirstName = "Alice", LastName = "Smith", Age = 30, Email = "alice@example.com" },
-<<<<<<< HEAD
         new() { FirstName = "Bob", LastName = "Jones", Age = 25, Email = "bob@example.com" },
     };
 
@@ -298,7 +290,19 @@ static async Task SchemaCustomizationExample()
     }
 
     Console.WriteLine($"Extracted: {extractor.CurrentItemCount}");
-=======
+}
+
+
+
+static async Task SchemaCustomizationExample()
+{
+    Console.WriteLine("=== Schema Customization Example ===");
+    Console.WriteLine("Customize JSON serialization without modifying the POCO class.");
+    Console.WriteLine();
+
+    var people = new List<Person>
+    {
+        new() { FirstName = "Alice", LastName = "Smith", Age = 30, Email = "alice@example.com" },
     };
 
     // --- snake_case naming policy ---
@@ -343,5 +347,4 @@ static async Task SchemaCustomizationExample()
     ignoreStream.Position = 0;
     using var ignoreReader = new StreamReader(ignoreStream);
     Console.WriteLine("  " + await ignoreReader.ReadToEndAsync());
->>>>>>> a4a7f83 (docs: add schema customization examples and guide (#18))
 }

--- a/examples/Wolfgang.Etl.Json.Examples/Program.cs
+++ b/examples/Wolfgang.Etl.Json.Examples/Program.cs
@@ -30,6 +30,8 @@ Console.WriteLine();
 await SkipAndMaxExample();
 Console.WriteLine();
 await CompressedStreamsExample();
+Console.WriteLine();
+await SchemaCustomizationExample();
 
 
 
@@ -255,15 +257,23 @@ static async Task SkipAndMaxExample()
 
 
 
+<<<<<<< HEAD
 static async Task CompressedStreamsExample()
 {
     Console.WriteLine("=== Compressed Streams Example ===");
     Console.WriteLine("The extractors and loaders accept any Stream, including compression wrappers.");
+=======
+static async Task SchemaCustomizationExample()
+{
+    Console.WriteLine("=== Schema Customization Example ===");
+    Console.WriteLine("Customize JSON serialization without modifying the POCO class.");
+>>>>>>> a4a7f83 (docs: add schema customization examples and guide (#18))
     Console.WriteLine();
 
     var people = new List<Person>
     {
         new() { FirstName = "Alice", LastName = "Smith", Age = 30, Email = "alice@example.com" },
+<<<<<<< HEAD
         new() { FirstName = "Bob", LastName = "Jones", Age = 25, Email = "bob@example.com" },
     };
 
@@ -288,4 +298,50 @@ static async Task CompressedStreamsExample()
     }
 
     Console.WriteLine($"Extracted: {extractor.CurrentItemCount}");
+=======
+    };
+
+    // --- snake_case naming policy ---
+    Console.WriteLine("snake_case naming policy:");
+    var snakeOptions = new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    var snakeStream = new MemoryStream();
+    var snakeLoader = new JsonLineLoader<Person>(snakeStream, snakeOptions);
+    await snakeLoader.LoadAsync(people.ToAsyncEnumerable());
+
+    snakeStream.Position = 0;
+    using var snakeReader = new StreamReader(snakeStream);
+    Console.WriteLine("  " + await snakeReader.ReadToEndAsync());
+
+    // --- Ignore a property via JsonSerializerOptions ---
+    Console.WriteLine("Ignore Email via options:");
+    var ignoreOptions = new JsonSerializerOptions();
+    ignoreOptions.TypeInfoResolverChain.Add(new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver
+    {
+        Modifiers =
+        {
+            typeInfo =>
+            {
+                if (typeInfo.Type != typeof(Person)) return;
+                foreach (var prop in typeInfo.Properties)
+                {
+                    if (string.Equals(prop.Name, "Email", StringComparison.Ordinal))
+                        prop.ShouldSerialize = (_, _) => false;
+                }
+            }
+        }
+    });
+
+    var ignoreStream = new MemoryStream();
+    var ignoreLoader = new JsonLineLoader<Person>(ignoreStream, ignoreOptions);
+    await ignoreLoader.LoadAsync(people.ToAsyncEnumerable());
+
+    ignoreStream.Position = 0;
+    using var ignoreReader = new StreamReader(ignoreStream);
+    Console.WriteLine("  " + await ignoreReader.ReadToEndAsync());
+>>>>>>> a4a7f83 (docs: add schema customization examples and guide (#18))
 }

--- a/examples/Wolfgang.Etl.Json.Examples/Program.cs
+++ b/examples/Wolfgang.Etl.Json.Examples/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
@@ -27,6 +28,8 @@ Console.WriteLine();
 await CustomOptionsExample(loggerFactory);
 Console.WriteLine();
 await SkipAndMaxExample();
+Console.WriteLine();
+await CompressedStreamsExample();
 
 
 
@@ -248,4 +251,41 @@ static async Task SkipAndMaxExample()
     }
 
     Console.WriteLine($"Extracted: {extractor.CurrentItemCount}, Skipped: {extractor.CurrentSkippedItemCount}");
+}
+
+
+
+static async Task CompressedStreamsExample()
+{
+    Console.WriteLine("=== Compressed Streams Example ===");
+    Console.WriteLine("The extractors and loaders accept any Stream, including compression wrappers.");
+    Console.WriteLine();
+
+    var people = new List<Person>
+    {
+        new() { FirstName = "Alice", LastName = "Smith", Age = 30, Email = "alice@example.com" },
+        new() { FirstName = "Bob", LastName = "Jones", Age = 25, Email = "bob@example.com" },
+    };
+
+    // --- Load to GZip-compressed JSONL ---
+    var compressed = new MemoryStream();
+    using (var gzipWrite = new GZipStream(compressed, CompressionLevel.Optimal, leaveOpen: true))
+    {
+        var loader = new JsonLineLoader<Person>(gzipWrite);
+        await loader.LoadAsync(people.ToAsyncEnumerable());
+        Console.WriteLine($"Loaded {loader.CurrentItemCount} items to GZip-compressed JSONL ({compressed.Length} bytes compressed).");
+    }
+
+    // --- Extract back from GZip-compressed JSONL ---
+    compressed.Position = 0;
+    using var gzipRead = new GZipStream(compressed, CompressionMode.Decompress);
+    var extractor = new JsonLineExtractor<Person>(gzipRead);
+
+    Console.WriteLine("Extracted items:");
+    await foreach (var person in extractor.ExtractAsync())
+    {
+        Console.WriteLine($"  {person.FirstName} {person.LastName}, age {person.Age}");
+    }
+
+    Console.WriteLine($"Extracted: {extractor.CurrentItemCount}");
 }

--- a/src/Wolfgang.Etl.Json/EtlPipelineJsonSinkExtensions.cs
+++ b/src/Wolfgang.Etl.Json/EtlPipelineJsonSinkExtensions.cs
@@ -167,6 +167,6 @@ public static class EtlPipelineJsonSinkExtensions
         var loader = options is null
             ? new JsonSingleStreamLoader<T>(stream)
             : new JsonSingleStreamLoader<T>(stream, options);
-        return pipeline.To(loader).DisposingOwned(stream);
+        return pipeline.To(loader);
     }
 }

--- a/src/Wolfgang.Etl.Json/EtlPipelineJsonSinkExtensions.cs
+++ b/src/Wolfgang.Etl.Json/EtlPipelineJsonSinkExtensions.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text.Json;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.Json;
+
+/// <summary>
+/// Class-named JSON sink terminators for the fluent <see cref="EtlPipeline"/> chain. Each terminator
+/// constructs the matching loader and terminates the pipeline, enabling
+/// <c>… .JsonLineLoader&lt;Person&gt;("people.jsonl")</c>.
+/// </summary>
+/// <remarks>
+/// Path-based terminators own the file stream they create and dispose it after the run completes
+/// (success or failure). Stream-based terminators do not dispose — the caller owns the stream.
+/// </remarks>
+public static class EtlPipelineJsonSinkExtensions
+{
+    /// <summary>
+    /// Terminates the pipeline, writing each record as a line of JSONL to a file.
+    /// </summary>
+    /// <typeparam name="T">The record type to serialize.</typeparam>
+    /// <param name="pipeline">The pipeline to terminate.</param>
+    /// <param name="path">The path of the JSONL file to write.</param>
+    /// <param name="options">Optional serializer options.</param>
+    /// <returns>A runnable <see cref="IEtlPipelineSink"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
+#if NET5_0_OR_GREATER
+    [RequiresUnreferencedCode("JSON serialization of unknown types may require types that cannot be statically analyzed.")]
+    [RequiresDynamicCode("JSON serialization of unknown types may require types that cannot be statically analyzed.")]
+#endif
+    public static IEtlPipelineSink JsonLineLoader<T>
+    (
+        this IEtlPipeline<T> pipeline,
+        string path,
+        JsonSerializerOptions? options = null
+    )
+        where T : notnull
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (path is null)
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        var stream = File.Create(path);
+        var loader = options is null
+            ? new JsonLineLoader<T>(stream)
+            : new JsonLineLoader<T>(stream, options);
+        return pipeline.To(loader).DisposingOwned(stream);
+    }
+
+
+    /// <summary>
+    /// Terminates the pipeline, writing each record as a line of JSONL to a stream. The caller owns the stream.
+    /// </summary>
+    /// <typeparam name="T">The record type to serialize.</typeparam>
+    /// <param name="pipeline">The pipeline to terminate.</param>
+    /// <param name="stream">The stream to write JSONL to.</param>
+    /// <param name="options">Optional serializer options.</param>
+    /// <returns>A runnable <see cref="IEtlPipelineSink"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
+#if NET5_0_OR_GREATER
+    [RequiresUnreferencedCode("JSON serialization of unknown types may require types that cannot be statically analyzed.")]
+    [RequiresDynamicCode("JSON serialization of unknown types may require types that cannot be statically analyzed.")]
+#endif
+    public static IEtlPipelineSink JsonLineLoader<T>
+    (
+        this IEtlPipeline<T> pipeline,
+        Stream stream,
+        JsonSerializerOptions? options = null
+    )
+        where T : notnull
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (stream is null)
+        {
+            throw new ArgumentNullException(nameof(stream));
+        }
+
+        var loader = options is null
+            ? new JsonLineLoader<T>(stream)
+            : new JsonLineLoader<T>(stream, options);
+        return pipeline.To(loader);
+    }
+
+
+    /// <summary>
+    /// Terminates the pipeline, writing all records as a single JSON array to a file.
+    /// </summary>
+    /// <typeparam name="T">The record type to serialize.</typeparam>
+    /// <param name="pipeline">The pipeline to terminate.</param>
+    /// <param name="path">The path of the JSON array file to write.</param>
+    /// <param name="options">Optional serializer options.</param>
+    /// <returns>A runnable <see cref="IEtlPipelineSink"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
+#if NET5_0_OR_GREATER
+    [RequiresUnreferencedCode("JSON serialization of unknown types may require types that cannot be statically analyzed.")]
+    [RequiresDynamicCode("JSON serialization of unknown types may require types that cannot be statically analyzed.")]
+#endif
+    public static IEtlPipelineSink JsonSingleStreamLoader<T>
+    (
+        this IEtlPipeline<T> pipeline,
+        string path,
+        JsonSerializerOptions? options = null
+    )
+        where T : notnull
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (path is null)
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        var stream = File.Create(path);
+        var loader = options is null
+            ? new JsonSingleStreamLoader<T>(stream)
+            : new JsonSingleStreamLoader<T>(stream, options);
+        return pipeline.To(loader).DisposingOwned(stream);
+    }
+
+
+    /// <summary>
+    /// Terminates the pipeline, writing all records as a single JSON array to a stream. The caller owns the stream.
+    /// </summary>
+    /// <typeparam name="T">The record type to serialize.</typeparam>
+    /// <param name="pipeline">The pipeline to terminate.</param>
+    /// <param name="stream">The stream to write the JSON array to.</param>
+    /// <param name="options">Optional serializer options.</param>
+    /// <returns>A runnable <see cref="IEtlPipelineSink"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
+#if NET5_0_OR_GREATER
+    [RequiresUnreferencedCode("JSON serialization of unknown types may require types that cannot be statically analyzed.")]
+    [RequiresDynamicCode("JSON serialization of unknown types may require types that cannot be statically analyzed.")]
+#endif
+    public static IEtlPipelineSink JsonSingleStreamLoader<T>
+    (
+        this IEtlPipeline<T> pipeline,
+        Stream stream,
+        JsonSerializerOptions? options = null
+    )
+        where T : notnull
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (stream is null)
+        {
+            throw new ArgumentNullException(nameof(stream));
+        }
+
+        var loader = options is null
+            ? new JsonSingleStreamLoader<T>(stream)
+            : new JsonSingleStreamLoader<T>(stream, options);
+        return pipeline.To(loader).DisposingOwned(stream);
+    }
+}

--- a/src/Wolfgang.Etl.Json/EtlPipelineJsonSourceExtensions.cs
+++ b/src/Wolfgang.Etl.Json/EtlPipelineJsonSourceExtensions.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.Json;
+
+/// <summary>
+/// Class-named JSON source factories for the fluent <see cref="EtlPipeline"/> chain. Each factory
+/// constructs the matching extractor and seeds the pipeline, enabling
+/// <c>EtlPipeline.Create().JsonLineExtractor&lt;Person&gt;("people.jsonl")</c>.
+/// </summary>
+/// <remarks>
+/// Path-based factories own the file stream they open and dispose it when the pipeline finishes
+/// enumerating. Stream-based factories do not dispose — the caller owns the stream's lifetime.
+/// </remarks>
+public static class EtlPipelineJsonSourceExtensions
+{
+    /// <summary>
+    /// Starts a pipeline that reads JSONL (JSON Lines / NDJSON) records from a file.
+    /// </summary>
+    /// <typeparam name="T">The record type to deserialize.</typeparam>
+    /// <param name="pipeline">The pipeline seed from <see cref="EtlPipeline.Create"/>.</param>
+    /// <param name="path">The path of the JSONL file to read.</param>
+    /// <param name="options">Optional serializer options.</param>
+    /// <returns>An <see cref="IEtlPipeline{T}"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
+#if NET5_0_OR_GREATER
+    [RequiresUnreferencedCode("JSON deserialization of unknown types may require types that cannot be statically analyzed.")]
+    [RequiresDynamicCode("JSON deserialization of unknown types may require types that cannot be statically analyzed.")]
+#endif
+    public static IEtlPipeline<T> JsonLineExtractor<T>
+    (
+        this EtlPipeline pipeline,
+        string path,
+        JsonSerializerOptions? options = null
+    )
+        where T : notnull
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (path is null)
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        return pipeline.From(ReadJsonLinesAsync<T>(path, options));
+    }
+
+
+    /// <summary>
+    /// Starts a pipeline that reads JSONL records from an existing stream. The caller owns the stream.
+    /// </summary>
+    /// <typeparam name="T">The record type to deserialize.</typeparam>
+    /// <param name="pipeline">The pipeline seed from <see cref="EtlPipeline.Create"/>.</param>
+    /// <param name="stream">The stream to read JSONL from.</param>
+    /// <param name="options">Optional serializer options.</param>
+    /// <returns>An <see cref="IEtlPipeline{T}"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
+#if NET5_0_OR_GREATER
+    [RequiresUnreferencedCode("JSON deserialization of unknown types may require types that cannot be statically analyzed.")]
+    [RequiresDynamicCode("JSON deserialization of unknown types may require types that cannot be statically analyzed.")]
+#endif
+    public static IEtlPipeline<T> JsonLineExtractor<T>
+    (
+        this EtlPipeline pipeline,
+        Stream stream,
+        JsonSerializerOptions? options = null
+    )
+        where T : notnull
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (stream is null)
+        {
+            throw new ArgumentNullException(nameof(stream));
+        }
+
+        var extractor = options is null
+            ? new JsonLineExtractor<T>(stream)
+            : new JsonLineExtractor<T>(stream, options);
+        return pipeline.From(extractor);
+    }
+
+
+    /// <summary>
+    /// Starts a pipeline that reads records from a single JSON array file.
+    /// </summary>
+    /// <typeparam name="T">The record type to deserialize.</typeparam>
+    /// <param name="pipeline">The pipeline seed from <see cref="EtlPipeline.Create"/>.</param>
+    /// <param name="path">The path of the JSON array file to read.</param>
+    /// <param name="options">Optional serializer options.</param>
+    /// <returns>An <see cref="IEtlPipeline{T}"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
+#if NET5_0_OR_GREATER
+    [RequiresUnreferencedCode("JSON deserialization of unknown types may require types that cannot be statically analyzed.")]
+    [RequiresDynamicCode("JSON deserialization of unknown types may require types that cannot be statically analyzed.")]
+#endif
+    public static IEtlPipeline<T> JsonSingleStreamExtractor<T>
+    (
+        this EtlPipeline pipeline,
+        string path,
+        JsonSerializerOptions? options = null
+    )
+        where T : notnull
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (path is null)
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        return pipeline.From(ReadJsonArrayAsync<T>(path, options));
+    }
+
+
+    /// <summary>
+    /// Starts a pipeline that reads records from a single JSON array stream. The caller owns the stream.
+    /// </summary>
+    /// <typeparam name="T">The record type to deserialize.</typeparam>
+    /// <param name="pipeline">The pipeline seed from <see cref="EtlPipeline.Create"/>.</param>
+    /// <param name="stream">The stream to read the JSON array from.</param>
+    /// <param name="options">Optional serializer options.</param>
+    /// <returns>An <see cref="IEtlPipeline{T}"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
+#if NET5_0_OR_GREATER
+    [RequiresUnreferencedCode("JSON deserialization of unknown types may require types that cannot be statically analyzed.")]
+    [RequiresDynamicCode("JSON deserialization of unknown types may require types that cannot be statically analyzed.")]
+#endif
+    public static IEtlPipeline<T> JsonSingleStreamExtractor<T>
+    (
+        this EtlPipeline pipeline,
+        Stream stream,
+        JsonSerializerOptions? options = null
+    )
+        where T : notnull
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (stream is null)
+        {
+            throw new ArgumentNullException(nameof(stream));
+        }
+
+        var extractor = options is null
+            ? new JsonSingleStreamExtractor<T>(stream)
+            : new JsonSingleStreamExtractor<T>(stream, options);
+        return pipeline.From(extractor);
+    }
+
+
+#if NET5_0_OR_GREATER
+    [RequiresUnreferencedCode("JSON deserialization of unknown types may require types that cannot be statically analyzed.")]
+    [RequiresDynamicCode("JSON deserialization of unknown types may require types that cannot be statically analyzed.")]
+#endif
+    private static async IAsyncEnumerable<T> ReadJsonLinesAsync<T>
+    (
+        string path,
+        JsonSerializerOptions? options,
+        [EnumeratorCancellation] CancellationToken token = default
+    )
+        where T : notnull
+    {
+#if NETSTANDARD2_0 || NET462 || NET481
+        using var stream = File.OpenRead(path);
+#else
+        await using var stream = File.OpenRead(path);
+#endif
+        var extractor = options is null
+            ? new JsonLineExtractor<T>(stream)
+            : new JsonLineExtractor<T>(stream, options);
+        await foreach (var item in extractor.ExtractAsync(token).ConfigureAwait(false))
+        {
+            yield return item;
+        }
+    }
+
+
+#if NET5_0_OR_GREATER
+    [RequiresUnreferencedCode("JSON deserialization of unknown types may require types that cannot be statically analyzed.")]
+    [RequiresDynamicCode("JSON deserialization of unknown types may require types that cannot be statically analyzed.")]
+#endif
+    private static async IAsyncEnumerable<T> ReadJsonArrayAsync<T>
+    (
+        string path,
+        JsonSerializerOptions? options,
+        [EnumeratorCancellation] CancellationToken token = default
+    )
+        where T : notnull
+    {
+#if NETSTANDARD2_0 || NET462 || NET481
+        using var stream = File.OpenRead(path);
+#else
+        await using var stream = File.OpenRead(path);
+#endif
+        var extractor = options is null
+            ? new JsonSingleStreamExtractor<T>(stream)
+            : new JsonSingleStreamExtractor<T>(stream, options);
+        await foreach (var item in extractor.ExtractAsync(token).ConfigureAwait(false))
+        {
+            yield return item;
+        }
+    }
+}

--- a/src/Wolfgang.Etl.Json/EtlPipelineJsonSourceExtensions.cs
+++ b/src/Wolfgang.Etl.Json/EtlPipelineJsonSourceExtensions.cs
@@ -1,11 +1,7 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
 
 namespace Wolfgang.Etl.Json;
@@ -52,7 +48,7 @@ public static class EtlPipelineJsonSourceExtensions
             throw new ArgumentNullException(nameof(path));
         }
 
-        return pipeline.From(ReadJsonLinesAsync<T>(path, options));
+        return pipeline.From(new JsonLineExtractor<T>(path, options));
     }
 
 
@@ -125,7 +121,7 @@ public static class EtlPipelineJsonSourceExtensions
             throw new ArgumentNullException(nameof(path));
         }
 
-        return pipeline.From(ReadJsonArrayAsync<T>(path, options));
+        return pipeline.From(new JsonSingleStreamExtractor<T>(path, options));
     }
 
 
@@ -164,59 +160,5 @@ public static class EtlPipelineJsonSourceExtensions
             ? new JsonSingleStreamExtractor<T>(stream)
             : new JsonSingleStreamExtractor<T>(stream, options);
         return pipeline.From(extractor);
-    }
-
-
-#if NET5_0_OR_GREATER
-    [RequiresUnreferencedCode("JSON deserialization of unknown types may require types that cannot be statically analyzed.")]
-    [RequiresDynamicCode("JSON deserialization of unknown types may require types that cannot be statically analyzed.")]
-#endif
-    private static async IAsyncEnumerable<T> ReadJsonLinesAsync<T>
-    (
-        string path,
-        JsonSerializerOptions? options,
-        [EnumeratorCancellation] CancellationToken token = default
-    )
-        where T : notnull
-    {
-#if NETSTANDARD2_0 || NET462 || NET481
-        using var stream = File.OpenRead(path);
-#else
-        await using var stream = File.OpenRead(path);
-#endif
-        var extractor = options is null
-            ? new JsonLineExtractor<T>(stream)
-            : new JsonLineExtractor<T>(stream, options);
-        await foreach (var item in extractor.ExtractAsync(token).ConfigureAwait(false))
-        {
-            yield return item;
-        }
-    }
-
-
-#if NET5_0_OR_GREATER
-    [RequiresUnreferencedCode("JSON deserialization of unknown types may require types that cannot be statically analyzed.")]
-    [RequiresDynamicCode("JSON deserialization of unknown types may require types that cannot be statically analyzed.")]
-#endif
-    private static async IAsyncEnumerable<T> ReadJsonArrayAsync<T>
-    (
-        string path,
-        JsonSerializerOptions? options,
-        [EnumeratorCancellation] CancellationToken token = default
-    )
-        where T : notnull
-    {
-#if NETSTANDARD2_0 || NET462 || NET481
-        using var stream = File.OpenRead(path);
-#else
-        await using var stream = File.OpenRead(path);
-#endif
-        var extractor = options is null
-            ? new JsonSingleStreamExtractor<T>(stream)
-            : new JsonSingleStreamExtractor<T>(stream, options);
-        await foreach (var item in extractor.ExtractAsync(token).ConfigureAwait(false))
-        {
-            yield return item;
-        }
     }
 }

--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -42,6 +42,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
     private static readonly KeyValuePair<string, object?> _componentTag = new("etl.component", "JsonLine");
     private static readonly KeyValuePair<string, object?> _recordTypeTag = new("etl.record_type", typeof(TRecord).Name);
     private readonly Stream _stream;
+    private readonly bool _ownsStream;
     private readonly JsonSerializerOptions? _options;
     private readonly JsonTypeInfo<TRecord>? _typeInfo;
     private readonly ILogger _logger;
@@ -122,6 +123,39 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
         _stream = stream ?? throw new ArgumentNullException(nameof(stream));
         _logger = NullLogger.Instance;
         _options = null;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonLineExtractor{TRecord}"/> class that opens
+    /// and owns the JSONL file at <paramref name="path"/>. The file is closed when extraction
+    /// completes or the extractor is disposed.
+    /// </summary>
+    /// <param name="path">The path of the JSONL file to read.</param>
+    /// <param name="options">The JSON serializer options to use, or <c>null</c> for the default.</param>
+    /// <param name="logger">An optional logger instance for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="path"/> is <c>null</c>.</exception>
+#if NET5_0_OR_GREATER
+    [RequiresUnreferencedCode("JSON deserialization of unknown types may require types that cannot be statically analyzed. Use the JsonTypeInfo overload for AOT compatibility.")]
+    [RequiresDynamicCode("JSON deserialization of unknown types may require types that cannot be statically analyzed. Use the JsonTypeInfo overload for AOT compatibility.")]
+#endif
+    public JsonLineExtractor
+    (
+        string path,
+        JsonSerializerOptions? options = null,
+        ILogger<JsonLineExtractor<TRecord>>? logger = null
+    )
+    {
+        if (path is null)
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        _stream = File.OpenRead(path);
+        _ownsStream = true;
+        _options = options;
+        _logger = logger ?? (ILogger)NullLogger.Instance;
     }
 
 
@@ -276,12 +310,12 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
     {
 #if NETSTANDARD2_0 || NET462 || NET481
         return Encoding is null
-            ? new StreamReader(_stream, System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true)
-            : new StreamReader(_stream, Encoding, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
+            ? new StreamReader(_stream, System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: !_ownsStream)
+            : new StreamReader(_stream, Encoding, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: !_ownsStream);
 #else
         return Encoding is null
-            ? new StreamReader(_stream, leaveOpen: true)
-            : new StreamReader(_stream, Encoding, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
+            ? new StreamReader(_stream, leaveOpen: !_ownsStream)
+            : new StreamReader(_stream, Encoding, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: !_ownsStream);
 #endif
     }
 
@@ -473,5 +507,18 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
         }
 
         return base.CreateProgressTimer(progress);
+    }
+
+
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && _ownsStream)
+        {
+            _stream.Dispose();
+        }
+
+        base.Dispose(disposing);
     }
 }

--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -287,8 +287,18 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
                 JsonLogMessages.SkippingBlankLine(_logger, lineNum, null);
                 continue;
             }
-            if (!TryDeserializeLine(line, lineNum, out var item)) { Interlocked.Add(ref _currentByteOffset, lineBytes); continue; }
-            if (item is null) { Interlocked.Add(ref _currentByteOffset, lineBytes); JsonLogMessages.LineDeserializedToNull(_logger, lineNum, null); continue; }
+            if (!TryDeserializeLine(line, lineNum, out var item))
+            {
+                Interlocked.Add(ref _currentByteOffset, lineBytes);
+                continue;
+            }
+
+            if (item is null)
+            {
+                Interlocked.Add(ref _currentByteOffset, lineBytes);
+                JsonLogMessages.LineDeserializedToNull(_logger, lineNum, null);
+                continue;
+            }
             if (skipBudget > 0)
             {
                 skipBudget--;

--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -63,6 +63,22 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
 
 
     /// <summary>
+    /// Gets or sets a value indicating whether the extractor tracks the byte offset of each line
+    /// so that <see cref="CurrentByteOffset"/> can be captured as a resumable checkpoint.
+    /// Default is <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// Tracking requires computing the byte length of every line, which adds measurable per-line
+    /// overhead on the extraction hot path. It is therefore opt-in: leave this <see langword="false"/>
+    /// unless you intend to read <see cref="CurrentByteOffset"/> to create checkpoints. Resuming a
+    /// prior run via <see cref="StartByteOffset"/> does not by itself require this flag — set it only
+    /// when you also need to capture new checkpoints during the resumed run.
+    /// </remarks>
+    public bool EnableCheckpointing { get; set; }
+
+
+
+    /// <summary>
     /// Gets or sets the byte offset within the stream at which extraction begins.
     /// Set this before calling <see cref="ExtractorBase{TSource,TProgress}.ExtractAsync(System.Threading.CancellationToken)"/> to resume from a saved checkpoint.
     /// The stream must be seekable when this value is greater than zero.
@@ -76,7 +92,14 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
     /// Gets the byte offset of the start of the next unread line in the stream.
     /// Capture this value after each <see langword="yield"/> to create a resumable checkpoint.
     /// </summary>
-    public long CurrentByteOffset => Interlocked.Read(ref _currentByteOffset);
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="EnableCheckpointing"/> is <see langword="false"/>. Byte offsets are
+    /// only tracked when checkpointing is enabled.
+    /// </exception>
+    public long CurrentByteOffset =>
+        EnableCheckpointing
+            ? Interlocked.Read(ref _currentByteOffset)
+            : throw new InvalidOperationException("Set EnableCheckpointing to true before reading CurrentByteOffset.");
 
 
 
@@ -272,6 +295,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
     {
         _errors.Clear();
         JsonLogMessages.StartingOperation(_logger, OperationName, null);
+        var track = EnableCheckpointing;
         var (newlineSize, lineEncoding) = await PrepareForExtractionAsync(token).ConfigureAwait(false);
         var skipBudget = SkipItemCount;
         var sw = Stopwatch.StartNew();
@@ -284,7 +308,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
 #endif
         {
             token.ThrowIfCancellationRequested();
-            var lineBytes = lineEncoding.GetByteCount(line) + newlineSize;
+            var lineBytes = track ? lineEncoding.GetByteCount(line) + newlineSize : 0;
             var lineNum = Interlocked.Increment(ref _currentLineNumber);
             if (string.IsNullOrWhiteSpace(line))
             {
@@ -348,7 +372,9 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
         Interlocked.Exchange(ref _currentLineNumber, 0);
         Interlocked.Exchange(ref _currentByteOffset, StartByteOffset);
         var lineEncoding = Encoding ?? System.Text.Encoding.UTF8;
-        var newlineSize = await DetectNewlineSizeAsync(token).ConfigureAwait(false);
+        var newlineSize = EnableCheckpointing
+            ? await DetectNewlineSizeAsync(token).ConfigureAwait(false)
+            : 0;
         if (StartByteOffset > 0)
         {
             if (!_stream.CanSeek)

--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -309,7 +309,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
                 skipBudget--;
                 Interlocked.Add(ref _currentByteOffset, lineBytes);
                 IncrementCurrentSkippedItemCount();
-                JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                JsonMetrics.AddSkipped(_operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.SkippedItemAtLine(_logger, CurrentSkippedItemCount, SkipItemCount, lineNum, null);
                 continue;
             }
@@ -320,7 +320,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
             }
             Interlocked.Add(ref _currentByteOffset, lineBytes);
             IncrementCurrentItemCount();
-            JsonMetrics.ItemsExtracted.Add(1, _operationTag, _componentTag, _recordTypeTag);
+            JsonMetrics.AddExtracted(_operationTag, _componentTag, _recordTypeTag);
             JsonLogMessages.ExtractedItemFromLine(_logger, CurrentItemCount, lineNum, null);
             yield return item;
         }
@@ -338,7 +338,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
         }
 
         JsonLogMessages.JsonlExtractionCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, Interlocked.Read(ref _currentLineNumber), null);
-        JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
+        JsonMetrics.RecordDuration(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
     }
 
 

--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Wolfgang.Etl.Abstractions;
@@ -43,6 +45,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
     private readonly List<JsonDeserializationError> _errors = new();
     private int _progressTimerWired;
     private long _currentLineNumber;
+    private long _currentByteOffset;
 
 
 
@@ -52,6 +55,24 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
     /// stream's byte-order mark (BOM), falling back to UTF-8.
     /// </summary>
     public System.Text.Encoding? Encoding { get; set; }
+
+
+
+    /// <summary>
+    /// Gets or sets the byte offset within the stream at which extraction begins.
+    /// Set this before calling <see cref="ExtractorBase{TSource,TProgress}.ExtractAsync(System.Threading.CancellationToken)"/> to resume from a saved checkpoint.
+    /// The stream must be seekable when this value is greater than zero.
+    /// Default is <c>0</c> (start of stream).
+    /// </summary>
+    public long StartByteOffset { get; set; }
+
+
+
+    /// <summary>
+    /// Gets the byte offset of the start of the next unread line in the stream.
+    /// Capture this value after each <see langword="yield"/> to create a resumable checkpoint.
+    /// </summary>
+    public long CurrentByteOffset => Interlocked.Read(ref _currentByteOffset);
 
 
 
@@ -246,13 +267,10 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
     )
     {
         _errors.Clear();
-        Interlocked.Exchange(ref _currentLineNumber, 0);
         JsonLogMessages.StartingOperation(_logger, OperationName, null);
-
+        var (newlineSize, lineEncoding) = await PrepareForExtractionAsync(token).ConfigureAwait(false);
         var skipBudget = SkipItemCount;
-
         using var reader = CreateStreamReader();
-
         string? line;
 #if NETSTANDARD2_0 || NET462 || NET481
         while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) is not null)
@@ -261,43 +279,93 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
 #endif
         {
             token.ThrowIfCancellationRequested();
-            Interlocked.Increment(ref _currentLineNumber);
-            var lineNum = Interlocked.Read(ref _currentLineNumber);
-
+            var lineBytes = lineEncoding.GetByteCount(line) + newlineSize;
+            var lineNum = Interlocked.Increment(ref _currentLineNumber);
             if (string.IsNullOrWhiteSpace(line))
             {
+                Interlocked.Add(ref _currentByteOffset, lineBytes);
                 JsonLogMessages.SkippingBlankLine(_logger, lineNum, null);
                 continue;
             }
-
-            if (!TryDeserializeLine(line, lineNum, out var item)) { continue; }
-            if (item is null)
-            {
-                JsonLogMessages.LineDeserializedToNull(_logger, lineNum, null);
-                continue;
-            }
-
+            if (!TryDeserializeLine(line, lineNum, out var item)) { Interlocked.Add(ref _currentByteOffset, lineBytes); continue; }
+            if (item is null) { Interlocked.Add(ref _currentByteOffset, lineBytes); JsonLogMessages.LineDeserializedToNull(_logger, lineNum, null); continue; }
             if (skipBudget > 0)
             {
                 skipBudget--;
+                Interlocked.Add(ref _currentByteOffset, lineBytes);
                 IncrementCurrentSkippedItemCount();
                 JsonLogMessages.SkippedItemAtLine(_logger, CurrentSkippedItemCount, SkipItemCount, lineNum, null);
                 continue;
             }
-
             if (CurrentItemCount >= MaximumItemCount)
             {
                 JsonLogMessages.ReachedMaximumItemCount(_logger, MaximumItemCount, null);
                 break;
             }
-
+            Interlocked.Add(ref _currentByteOffset, lineBytes);
             IncrementCurrentItemCount();
             JsonLogMessages.ExtractedItemFromLine(_logger, CurrentItemCount, lineNum, null);
-
             yield return item;
         }
 
+        if (_stream.CanSeek && Interlocked.Read(ref _currentByteOffset) > _stream.Length)
+        {
+            Interlocked.Exchange(ref _currentByteOffset, _stream.Length);
+        }
+
         JsonLogMessages.JsonlExtractionCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, Interlocked.Read(ref _currentLineNumber), null);
+    }
+
+
+
+    private async Task<(int NewlineSize, Encoding LineEncoding)> PrepareForExtractionAsync(CancellationToken token)
+    {
+        Interlocked.Exchange(ref _currentLineNumber, 0);
+        Interlocked.Exchange(ref _currentByteOffset, StartByteOffset);
+        var lineEncoding = Encoding ?? System.Text.Encoding.UTF8;
+        var newlineSize = await DetectNewlineSizeAsync(token).ConfigureAwait(false);
+        if (StartByteOffset > 0)
+        {
+            if (!_stream.CanSeek)
+            {
+                throw new InvalidOperationException
+                (
+                    "Stream must be seekable when StartByteOffset is greater than zero."
+                );
+            }
+
+            _stream.Seek(StartByteOffset, SeekOrigin.Begin);
+        }
+
+        return (newlineSize, lineEncoding);
+    }
+
+
+
+    private async Task<int> DetectNewlineSizeAsync(CancellationToken token)
+    {
+        if (!_stream.CanSeek) { return 1; }
+
+        var savedPosition = _stream.Position;
+        _stream.Seek(0, SeekOrigin.Begin);
+        var buffer = new byte[256];
+#if NETSTANDARD2_0 || NET462 || NET481
+#pragma warning disable CA2016, MA0040 // old TFM overload has no CancellationToken parameter
+        var bytesRead = await _stream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+#pragma warning restore CA2016, MA0040
+        _ = token;
+#else
+        var bytesRead = await _stream.ReadAsync(buffer.AsMemory(0, buffer.Length), token).ConfigureAwait(false);
+#endif
+        _stream.Seek(savedPosition, SeekOrigin.Begin);
+
+        for (var i = 0; i < bytesRead - 1; i++)
+        {
+            if (buffer[i] == '\r' && buffer[i + 1] == '\n') { return 2; }
+            if (buffer[i] == '\n') { return 1; }
+        }
+
+        return 1;
     }
 
 

--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -37,6 +38,9 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSONL extraction of {typeof(TRecord).Name}";
+    private static readonly KeyValuePair<string, object?> _operationTag = new("etl.operation", "extract");
+    private static readonly KeyValuePair<string, object?> _componentTag = new("etl.component", "JsonLine");
+    private static readonly KeyValuePair<string, object?> _recordTypeTag = new("etl.record_type", typeof(TRecord).Name);
     private readonly Stream _stream;
     private readonly JsonSerializerOptions? _options;
     private readonly JsonTypeInfo<TRecord>? _typeInfo;
@@ -270,6 +274,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
         JsonLogMessages.StartingOperation(_logger, OperationName, null);
         var (newlineSize, lineEncoding) = await PrepareForExtractionAsync(token).ConfigureAwait(false);
         var skipBudget = SkipItemCount;
+        var sw = Stopwatch.StartNew();
         using var reader = CreateStreamReader();
         string? line;
 #if NETSTANDARD2_0 || NET462 || NET481
@@ -304,6 +309,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
                 skipBudget--;
                 Interlocked.Add(ref _currentByteOffset, lineBytes);
                 IncrementCurrentSkippedItemCount();
+                JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.SkippedItemAtLine(_logger, CurrentSkippedItemCount, SkipItemCount, lineNum, null);
                 continue;
             }
@@ -314,16 +320,25 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
             }
             Interlocked.Add(ref _currentByteOffset, lineBytes);
             IncrementCurrentItemCount();
+            JsonMetrics.ItemsExtracted.Add(1, _operationTag, _componentTag, _recordTypeTag);
             JsonLogMessages.ExtractedItemFromLine(_logger, CurrentItemCount, lineNum, null);
             yield return item;
         }
 
+        CompleteExtraction(sw);
+    }
+
+
+
+    private void CompleteExtraction(Stopwatch sw)
+    {
         if (_stream.CanSeek && Interlocked.Read(ref _currentByteOffset) > _stream.Length)
         {
             Interlocked.Exchange(ref _currentByteOffset, _stream.Length);
         }
 
         JsonLogMessages.JsonlExtractionCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, Interlocked.Read(ref _currentLineNumber), null);
+        JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
     }
 
 

--- a/src/Wolfgang.Etl.Json/JsonLineLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineLoader.cs
@@ -236,7 +236,7 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>, I
             if (CurrentSkippedItemCount < SkipItemCount)
             {
                 IncrementCurrentSkippedItemCount();
-                JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                JsonMetrics.AddSkipped(_operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
                 continue;
             }
@@ -272,12 +272,12 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>, I
             }
 
             IncrementCurrentItemCount();
-            JsonMetrics.ItemsLoaded.Add(1, _operationTag, _componentTag, _recordTypeTag);
+            JsonMetrics.AddLoaded(_operationTag, _componentTag, _recordTypeTag);
             JsonLogMessages.LoadedItemAtLine(_logger, CurrentItemCount, Interlocked.Read(ref _currentLineNumber), null);
         }
 
         JsonLogMessages.JsonlLoadingCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, Interlocked.Read(ref _currentLineNumber), null);
-        JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
+        JsonMetrics.RecordDuration(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
     }
 
 

--- a/src/Wolfgang.Etl.Json/JsonLineLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineLoader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.Json;
@@ -32,6 +33,9 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>, I
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSONL loading of {typeof(TRecord).Name}";
+    private static readonly KeyValuePair<string, object?> _operationTag = new("etl.operation", "load");
+    private static readonly KeyValuePair<string, object?> _componentTag = new("etl.component", "JsonLine");
+    private static readonly KeyValuePair<string, object?> _recordTypeTag = new("etl.record_type", typeof(TRecord).Name);
     private static readonly byte[] _newLineUtf8 = System.Text.Encoding.UTF8.GetBytes(Environment.NewLine);
     private readonly Stream _stream;
     private readonly JsonSerializerOptions? _options;
@@ -223,6 +227,7 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>, I
         JsonLogMessages.StartingOperation(_logger, OperationName, null);
 
         var newLine = Encoding is null ? _newLineUtf8 : Encoding.GetBytes(Environment.NewLine);
+        var sw = Stopwatch.StartNew();
 
         await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
         {
@@ -231,6 +236,7 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>, I
             if (CurrentSkippedItemCount < SkipItemCount)
             {
                 IncrementCurrentSkippedItemCount();
+                JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
                 continue;
             }
@@ -266,10 +272,12 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>, I
             }
 
             IncrementCurrentItemCount();
+            JsonMetrics.ItemsLoaded.Add(1, _operationTag, _componentTag, _recordTypeTag);
             JsonLogMessages.LoadedItemAtLine(_logger, CurrentItemCount, Interlocked.Read(ref _currentLineNumber), null);
         }
 
         JsonLogMessages.JsonlLoadingCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, Interlocked.Read(ref _currentLineNumber), null);
+        JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
     }
 
 

--- a/src/Wolfgang.Etl.Json/JsonMetrics.cs
+++ b/src/Wolfgang.Etl.Json/JsonMetrics.cs
@@ -34,4 +34,79 @@ internal static class JsonMetrics
             "wolfgang.etl.json.operation.duration",
             unit: "ms",
             description: "Duration of extract/load operations in milliseconds.");
+
+
+
+    /// <summary>
+    /// Records one extracted item. The <see cref="Instrument.Enabled"/> guard skips the
+    /// diagnostics machinery entirely when no listener is subscribed, keeping the hot path free.
+    /// </summary>
+    internal static void AddExtracted
+    (
+        KeyValuePair<string, object?> operation,
+        KeyValuePair<string, object?> component,
+        KeyValuePair<string, object?> recordType
+    )
+    {
+        if (ItemsExtracted.Enabled)
+        {
+            ItemsExtracted.Add(1, operation, component, recordType);
+        }
+    }
+
+
+
+    /// <summary>
+    /// Records one loaded item. See <see cref="AddExtracted"/> for the enabled-guard rationale.
+    /// </summary>
+    internal static void AddLoaded
+    (
+        KeyValuePair<string, object?> operation,
+        KeyValuePair<string, object?> component,
+        KeyValuePair<string, object?> recordType
+    )
+    {
+        if (ItemsLoaded.Enabled)
+        {
+            ItemsLoaded.Add(1, operation, component, recordType);
+        }
+    }
+
+
+
+    /// <summary>
+    /// Records one skipped item. See <see cref="AddExtracted"/> for the enabled-guard rationale.
+    /// </summary>
+    internal static void AddSkipped
+    (
+        KeyValuePair<string, object?> operation,
+        KeyValuePair<string, object?> component,
+        KeyValuePair<string, object?> recordType
+    )
+    {
+        if (ItemsSkipped.Enabled)
+        {
+            ItemsSkipped.Add(1, operation, component, recordType);
+        }
+    }
+
+
+
+    /// <summary>
+    /// Records an operation's duration in milliseconds. See <see cref="AddExtracted"/> for the
+    /// enabled-guard rationale.
+    /// </summary>
+    internal static void RecordDuration
+    (
+        double milliseconds,
+        KeyValuePair<string, object?> operation,
+        KeyValuePair<string, object?> component,
+        KeyValuePair<string, object?> recordType
+    )
+    {
+        if (OperationDuration.Enabled)
+        {
+            OperationDuration.Record(milliseconds, operation, component, recordType);
+        }
+    }
 }

--- a/src/Wolfgang.Etl.Json/JsonMetrics.cs
+++ b/src/Wolfgang.Etl.Json/JsonMetrics.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
+namespace Wolfgang.Etl.Json;
+
+internal static class JsonMetrics
+{
+    internal static readonly Meter Meter = new("Wolfgang.Etl.Json");
+
+
+    internal static readonly Counter<long> ItemsExtracted =
+        Meter.CreateCounter<long>(
+            "wolfgang.etl.json.items.extracted",
+            unit: null,
+            description: "Total items successfully extracted.");
+
+
+    internal static readonly Counter<long> ItemsLoaded =
+        Meter.CreateCounter<long>(
+            "wolfgang.etl.json.items.loaded",
+            unit: null,
+            description: "Total items successfully loaded.");
+
+
+    internal static readonly Counter<long> ItemsSkipped =
+        Meter.CreateCounter<long>(
+            "wolfgang.etl.json.items.skipped",
+            unit: null,
+            description: "Total items skipped via SkipItemCount.");
+
+
+    internal static readonly Histogram<double> OperationDuration =
+        Meter.CreateHistogram<double>(
+            "wolfgang.etl.json.operation.duration",
+            unit: "ms",
+            description: "Duration of extract/load operations in milliseconds.");
+}

--- a/src/Wolfgang.Etl.Json/JsonMultiStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonMultiStreamExtractor.cs
@@ -411,7 +411,7 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
                 {
                     skipBudget--;
                     IncrementCurrentSkippedItemCount();
-                    JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                    JsonMetrics.AddSkipped(_operationTag, _componentTag, _recordTypeTag);
                     JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
                     continue;
                 }
@@ -423,7 +423,7 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
                 }
 
                 IncrementCurrentItemCount();
-                JsonMetrics.ItemsExtracted.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                JsonMetrics.AddExtracted(_operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.ExtractedItemFromStream(_logger, CurrentItemCount, streamIndex - 1, null);
 
                 yield return item;
@@ -433,7 +433,7 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
         }
         finally
         {
-            JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
+            JsonMetrics.RecordDuration(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
         }
     }
 

--- a/src/Wolfgang.Etl.Json/JsonMultiStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonMultiStreamExtractor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -40,6 +41,9 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSON multi-stream extraction of {typeof(TRecord).Name}";
+    private static readonly KeyValuePair<string, object?> _operationTag = new("etl.operation", "extract");
+    private static readonly KeyValuePair<string, object?> _componentTag = new("etl.component", "JsonMultiStream");
+    private static readonly KeyValuePair<string, object?> _recordTypeTag = new("etl.record_type", typeof(TRecord).Name);
     private readonly IEnumerable<JsonNamedStream> _sources;
     private readonly JsonSerializerOptions? _options;
     private readonly JsonTypeInfo<TRecord>? _typeInfo;
@@ -383,44 +387,54 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
 
         var skipBudget = SkipItemCount;
         var streamIndex = 0;
+        var sw = Stopwatch.StartNew();
 
-        foreach (var source in _sources)
+        try
         {
-            token.ThrowIfCancellationRequested();
-            _currentSourceName = source.Name;
-            JsonLogMessages.ReadingStream(_logger, streamIndex, null);
-
-            var (item, failed) = await TryDeserializeStreamAsync(source.Stream, streamIndex, token).ConfigureAwait(false);
-            streamIndex++;
-            if (failed) { continue; }
-
-            if (item is null)
+            foreach (var source in _sources)
             {
-                JsonLogMessages.StreamDeserializedToNull(_logger, streamIndex - 1, null);
-                continue;
+                token.ThrowIfCancellationRequested();
+                _currentSourceName = source.Name;
+                JsonLogMessages.ReadingStream(_logger, streamIndex, null);
+
+                var (item, failed) = await TryDeserializeStreamAsync(source.Stream, streamIndex, token).ConfigureAwait(false);
+                streamIndex++;
+                if (failed) { continue; }
+
+                if (item is null)
+                {
+                    JsonLogMessages.StreamDeserializedToNull(_logger, streamIndex - 1, null);
+                    continue;
+                }
+
+                if (skipBudget > 0)
+                {
+                    skipBudget--;
+                    IncrementCurrentSkippedItemCount();
+                    JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                    JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
+                    continue;
+                }
+
+                if (CurrentItemCount >= MaximumItemCount)
+                {
+                    JsonLogMessages.ReachedMaximumItemCount(_logger, MaximumItemCount, null);
+                    break;
+                }
+
+                IncrementCurrentItemCount();
+                JsonMetrics.ItemsExtracted.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                JsonLogMessages.ExtractedItemFromStream(_logger, CurrentItemCount, streamIndex - 1, null);
+
+                yield return item;
             }
 
-            if (skipBudget > 0)
-            {
-                skipBudget--;
-                IncrementCurrentSkippedItemCount();
-                JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
-                continue;
-            }
-
-            if (CurrentItemCount >= MaximumItemCount)
-            {
-                JsonLogMessages.ReachedMaximumItemCount(_logger, MaximumItemCount, null);
-                break;
-            }
-
-            IncrementCurrentItemCount();
-            JsonLogMessages.ExtractedItemFromStream(_logger, CurrentItemCount, streamIndex - 1, null);
-
-            yield return item;
+            JsonLogMessages.MultiStreamExtractionCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, streamIndex, null);
         }
-
-        JsonLogMessages.MultiStreamExtractionCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, streamIndex, null);
+        finally
+        {
+            JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
+        }
     }
 
 

--- a/src/Wolfgang.Etl.Json/JsonMultiStreamLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonMultiStreamLoader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.Json;
@@ -36,6 +37,9 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSON multi-stream loading of {typeof(TRecord).Name}";
+    private static readonly KeyValuePair<string, object?> _operationTag = new("etl.operation", "load");
+    private static readonly KeyValuePair<string, object?> _componentTag = new("etl.component", "JsonMultiStream");
+    private static readonly KeyValuePair<string, object?> _recordTypeTag = new("etl.record_type", typeof(TRecord).Name);
     private readonly Func<TRecord, JsonNamedDestination> _destinationFactory;
     private readonly JsonSerializerOptions? _options;
     private readonly JsonTypeInfo<TRecord>? _typeInfo;
@@ -394,47 +398,58 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
         JsonLogMessages.StartingOperation(_logger, OperationName, null);
 
         var streamIndex = 0;
+        var sw = Stopwatch.StartNew();
 
-        await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
+        try
         {
-            token.ThrowIfCancellationRequested();
-
-            if (CurrentSkippedItemCount < SkipItemCount)
+            await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
             {
-                IncrementCurrentSkippedItemCount();
-                JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
-                continue;
-            }
+                token.ThrowIfCancellationRequested();
 
-            if (CurrentItemCount >= MaximumItemCount)
-            {
-                JsonLogMessages.ReachedMaximumItemCount(_logger, MaximumItemCount, null);
-                break;
-            }
+                if (CurrentSkippedItemCount < SkipItemCount)
+                {
+                    IncrementCurrentSkippedItemCount();
+                    JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                    JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
+                    continue;
+                }
 
-            if (IsDryRun)
-            {
-                _currentDestinationName = null;
+                if (CurrentItemCount >= MaximumItemCount)
+                {
+                    JsonLogMessages.ReachedMaximumItemCount(_logger, MaximumItemCount, null);
+                    break;
+                }
+
+                if (IsDryRun)
+                {
+                    _currentDestinationName = null;
+                    IncrementCurrentItemCount();
+                    JsonMetrics.ItemsLoaded.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                    streamIndex++;
+                    JsonLogMessages.LoadedItemToStream(_logger, CurrentItemCount, streamIndex - 1, null);
+                    continue;
+                }
+
+                var destination = _destinationFactory(item);
+                _currentDestinationName = destination?.Name;
+                if (destination?.Stream is null)
+                {
+                    JsonLogMessages.StreamFactoryReturnedNull(_logger, streamIndex, null);
+                    throw new InvalidOperationException($"Destination factory returned null or a null stream for item at index {streamIndex}.");
+                }
+                await WriteItemToStreamAsync(destination.Stream, item, streamIndex, token).ConfigureAwait(false);
                 IncrementCurrentItemCount();
+                JsonMetrics.ItemsLoaded.Add(1, _operationTag, _componentTag, _recordTypeTag);
                 streamIndex++;
                 JsonLogMessages.LoadedItemToStream(_logger, CurrentItemCount, streamIndex - 1, null);
-                continue;
             }
 
-            var destination = _destinationFactory(item);
-            _currentDestinationName = destination?.Name;
-            if (destination?.Stream is null)
-            {
-                JsonLogMessages.StreamFactoryReturnedNull(_logger, streamIndex, null);
-                throw new InvalidOperationException($"Destination factory returned null or a null stream for item at index {streamIndex}.");
-            }
-            await WriteItemToStreamAsync(destination.Stream, item, streamIndex, token).ConfigureAwait(false);
-            IncrementCurrentItemCount();
-            streamIndex++;
-            JsonLogMessages.LoadedItemToStream(_logger, CurrentItemCount, streamIndex - 1, null);
+            JsonLogMessages.MultiStreamLoadingCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, streamIndex, null);
         }
-
-        JsonLogMessages.MultiStreamLoadingCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, streamIndex, null);
+        finally
+        {
+            JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
+        }
     }
 
 

--- a/src/Wolfgang.Etl.Json/JsonMultiStreamLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonMultiStreamLoader.cs
@@ -409,7 +409,7 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
                 if (CurrentSkippedItemCount < SkipItemCount)
                 {
                     IncrementCurrentSkippedItemCount();
-                    JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                    JsonMetrics.AddSkipped(_operationTag, _componentTag, _recordTypeTag);
                     JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
                     continue;
                 }
@@ -424,7 +424,7 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
                 {
                     _currentDestinationName = null;
                     IncrementCurrentItemCount();
-                    JsonMetrics.ItemsLoaded.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                    JsonMetrics.AddLoaded(_operationTag, _componentTag, _recordTypeTag);
                     streamIndex++;
                     JsonLogMessages.LoadedItemToStream(_logger, CurrentItemCount, streamIndex - 1, null);
                     continue;
@@ -439,7 +439,7 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
                 }
                 await WriteItemToStreamAsync(destination.Stream, item, streamIndex, token).ConfigureAwait(false);
                 IncrementCurrentItemCount();
-                JsonMetrics.ItemsLoaded.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                JsonMetrics.AddLoaded(_operationTag, _componentTag, _recordTypeTag);
                 streamIndex++;
                 JsonLogMessages.LoadedItemToStream(_logger, CurrentItemCount, streamIndex - 1, null);
             }
@@ -448,7 +448,7 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
         }
         finally
         {
-            JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
+            JsonMetrics.RecordDuration(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
         }
     }
 

--- a/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
@@ -267,7 +267,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
                 {
                     skipBudget--;
                     IncrementCurrentSkippedItemCount();
-                    JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                    JsonMetrics.AddSkipped(_operationTag, _componentTag, _recordTypeTag);
                     JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
                     continue;
                 }
@@ -277,7 +277,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
                     break;
                 }
                 IncrementCurrentItemCount();
-                JsonMetrics.ItemsExtracted.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                JsonMetrics.AddExtracted(_operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.ExtractedItem(_logger, CurrentItemCount, null);
                 yield return item;
             }
@@ -285,7 +285,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
         finally
         {
             await enumerator.DisposeAsync().ConfigureAwait(false);
-            JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
+            JsonMetrics.RecordDuration(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
         }
 
         JsonLogMessages.SingleStreamExtractionCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, null);

--- a/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
@@ -44,6 +44,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
     private static readonly JsonSerializerOptions DefaultOptions = new();
 
     private readonly Stream _stream;
+    private readonly bool _ownsStream;
     private readonly JsonSerializerOptions? _options;
     private readonly JsonTypeInfo<TRecord>? _typeInfo;
     private readonly ILogger _logger;
@@ -72,6 +73,39 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
         _stream = stream ?? throw new ArgumentNullException(nameof(stream));
         _logger = NullLogger.Instance;
         _options = null;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonSingleStreamExtractor{TRecord}"/> class that
+    /// opens and owns the JSON array file at <paramref name="path"/>. The file is closed when
+    /// extraction completes or the extractor is disposed.
+    /// </summary>
+    /// <param name="path">The path of the JSON array file to read.</param>
+    /// <param name="options">The JSON serializer options to use, or <c>null</c> for the default.</param>
+    /// <param name="logger">An optional logger instance for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="path"/> is <c>null</c>.</exception>
+#if NET5_0_OR_GREATER
+    [RequiresUnreferencedCode("JSON deserialization of unknown types may require types that cannot be statically analyzed. Use the JsonTypeInfo overload for AOT compatibility.")]
+    [RequiresDynamicCode("JSON deserialization of unknown types may require types that cannot be statically analyzed. Use the JsonTypeInfo overload for AOT compatibility.")]
+#endif
+    public JsonSingleStreamExtractor
+    (
+        string path,
+        JsonSerializerOptions? options = null,
+        ILogger<JsonSingleStreamExtractor<TRecord>>? logger = null
+    )
+    {
+        if (path is null)
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        _stream = File.OpenRead(path);
+        _ownsStream = true;
+        _options = options;
+        _logger = logger ?? (ILogger)NullLogger.Instance;
     }
 
 
@@ -284,7 +318,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
         }
         finally
         {
-            await enumerator.DisposeAsync().ConfigureAwait(false);
+            await CleanupAsync(enumerator).ConfigureAwait(false);
             JsonMetrics.RecordDuration(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
         }
 
@@ -339,5 +373,44 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
         }
 
         return base.CreateProgressTimer(progress);
+    }
+
+
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && _ownsStream)
+        {
+            _stream.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+
+    // Disposes the deserialization enumerator, then the file stream this extractor opened (if any).
+    private async ValueTask CleanupAsync(IAsyncDisposable enumerator)
+    {
+        await enumerator.DisposeAsync().ConfigureAwait(false);
+        await DisposeOwnedStreamAsync().ConfigureAwait(false);
+    }
+
+
+    // Disposes the file stream this extractor opened (path-based ctor). No-op otherwise. Not async
+    // itself — returns the underlying DisposeAsync ValueTask so there is no CS1998 on the sync TFMs.
+    private ValueTask DisposeOwnedStreamAsync()
+    {
+        if (!_ownsStream)
+        {
+            return default;
+        }
+
+#if NETSTANDARD2_0 || NET462 || NET481
+        _stream.Dispose();
+        return default;
+#else
+        return _stream.DisposeAsync();
+#endif
     }
 }

--- a/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -37,6 +38,9 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSON single-stream extraction of {typeof(TRecord).Name}";
+    private static readonly KeyValuePair<string, object?> _operationTag = new("etl.operation", "extract");
+    private static readonly KeyValuePair<string, object?> _componentTag = new("etl.component", "JsonSingleStream");
+    private static readonly KeyValuePair<string, object?> _recordTypeTag = new("etl.record_type", typeof(TRecord).Name);
     private static readonly JsonSerializerOptions DefaultOptions = new();
 
     private readonly Stream _stream;
@@ -234,6 +238,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
         JsonLogMessages.StartingOperation(_logger, OperationName, null);
 
         var skipBudget = SkipItemCount;
+        var sw = Stopwatch.StartNew();
         var enumerable = _typeInfo is not null
             ? JsonSerializer.DeserializeAsyncEnumerable(_stream, _typeInfo, token)
             : JsonSerializer.DeserializeAsyncEnumerable<TRecord>(_stream, _options ?? DefaultOptions, token);
@@ -262,6 +267,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
                 {
                     skipBudget--;
                     IncrementCurrentSkippedItemCount();
+                    JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
                     JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
                     continue;
                 }
@@ -271,6 +277,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
                     break;
                 }
                 IncrementCurrentItemCount();
+                JsonMetrics.ItemsExtracted.Add(1, _operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.ExtractedItem(_logger, CurrentItemCount, null);
                 yield return item;
             }
@@ -278,6 +285,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
         finally
         {
             await enumerator.DisposeAsync().ConfigureAwait(false);
+            JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
         }
 
         JsonLogMessages.SingleStreamExtractionCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, null);

--- a/src/Wolfgang.Etl.Json/JsonSingleStreamLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonSingleStreamLoader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.Json;
@@ -31,6 +32,9 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
     where TRecord : notnull
 {
     private static readonly string OperationName = $"JSON single-stream loading of {typeof(TRecord).Name}";
+    private static readonly KeyValuePair<string, object?> _operationTag = new("etl.operation", "load");
+    private static readonly KeyValuePair<string, object?> _componentTag = new("etl.component", "JsonSingleStream");
+    private static readonly KeyValuePair<string, object?> _recordTypeTag = new("etl.record_type", typeof(TRecord).Name);
     private readonly Stream _stream;
     private readonly JsonSerializerOptions? _options;
     private readonly JsonTypeInfo<TRecord>? _typeInfo;
@@ -211,6 +215,8 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
     {
         JsonLogMessages.StartingOperation(_logger, OperationName, null);
 
+        var sw = Stopwatch.StartNew();
+
         // CA2007/MA0004: await using declarations do not support ConfigureAwait in C#
 #pragma warning disable CA2007, MA0004
         await using var writer = IsDryRun ? null : new Utf8JsonWriter(_stream);
@@ -225,6 +231,7 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
             if (CurrentSkippedItemCount < SkipItemCount)
             {
                 IncrementCurrentSkippedItemCount();
+                JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
                 continue;
             }
@@ -248,6 +255,7 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
             }
 
             IncrementCurrentItemCount();
+            JsonMetrics.ItemsLoaded.Add(1, _operationTag, _componentTag, _recordTypeTag);
             JsonLogMessages.LoadedItem(_logger, CurrentItemCount, null);
         }
 
@@ -258,6 +266,7 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
         }
 
         JsonLogMessages.SingleStreamLoadingCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, null);
+        JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
     }
 
 

--- a/src/Wolfgang.Etl.Json/JsonSingleStreamLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonSingleStreamLoader.cs
@@ -231,7 +231,7 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
             if (CurrentSkippedItemCount < SkipItemCount)
             {
                 IncrementCurrentSkippedItemCount();
-                JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                JsonMetrics.AddSkipped(_operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
                 continue;
             }
@@ -255,7 +255,7 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
             }
 
             IncrementCurrentItemCount();
-            JsonMetrics.ItemsLoaded.Add(1, _operationTag, _componentTag, _recordTypeTag);
+            JsonMetrics.AddLoaded(_operationTag, _componentTag, _recordTypeTag);
             JsonLogMessages.LoadedItem(_logger, CurrentItemCount, null);
         }
 
@@ -266,7 +266,7 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
         }
 
         JsonLogMessages.SingleStreamLoadingCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, null);
-        JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
+        JsonMetrics.RecordDuration(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
     }
 
 

--- a/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
+++ b/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +

--- a/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
+++ b/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.15.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.9" />
     <PackageReference Include="System.Text.Json" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>

--- a/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
+++ b/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.15.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.16.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.9" />
     <PackageReference Include="System.Text.Json" Version="10.0.9" />

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/EtlPipelineJsonExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/EtlPipelineJsonExtensionsTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.Json.Tests.Unit.TestModels;
+using Xunit;
+
+namespace Wolfgang.Etl.Json.Tests.Unit;
+
+public sealed class EtlPipelineJsonExtensionsTests
+{
+    private static readonly PersonRecord[] People =
+    {
+        new() { FirstName = "Alice", LastName = "Smith", Age = 30 },
+        new() { FirstName = "Bob", LastName = "Jones", Age = 25 },
+        new() { FirstName = "Carol", LastName = "White", Age = 35 },
+    };
+
+
+    [Fact]
+    public async Task JsonLine_stream_round_trip_via_pipeline()
+    {
+        // Arrange: a source JSONL stream.
+        var source = new MemoryStream(Encoding.UTF8.GetBytes(
+            string.Join("\n", People.Select(p => System.Text.Json.JsonSerializer.Serialize(p)))));
+        var destination = new MemoryStream();
+
+        // Act: JsonLineExtractor -> JsonLineLoader through the fluent EtlPipeline.
+        await EtlPipeline
+            .Create()
+            .JsonLineExtractor<PersonRecord>(source)
+            .JsonLineLoader<PersonRecord>(destination)
+            .RunAsync();
+
+        // Assert: reading the destination back yields the same records.
+        destination.Position = 0;
+        var readBack = new List<PersonRecord>();
+        await foreach (var p in new JsonLineExtractor<PersonRecord>(destination).ExtractAsync())
+        {
+            readBack.Add(p);
+        }
+
+        Assert.Equal(People, readBack);
+    }
+
+
+    [Fact]
+    public async Task JsonLine_file_round_trip_via_pipeline_disposes_streams()
+    {
+        var inPath = Path.GetTempFileName();
+        var outPath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(inPath,
+                string.Join("\n", People.Select(p => System.Text.Json.JsonSerializer.Serialize(p))));
+
+            await EtlPipeline
+                .Create()
+                .JsonLineExtractor<PersonRecord>(inPath)
+                .JsonLineLoader<PersonRecord>(outPath)
+                .RunAsync();
+
+            // If the factory-owned streams were not disposed, these opens would throw IOException.
+            var readBack = new List<PersonRecord>();
+            using (var outStream = File.OpenRead(outPath))
+            {
+                await foreach (var p in new JsonLineExtractor<PersonRecord>(outStream).ExtractAsync())
+                {
+                    readBack.Add(p);
+                }
+            }
+
+            Assert.Equal(People, readBack);
+        }
+        finally
+        {
+            File.Delete(inPath);
+            File.Delete(outPath);
+        }
+    }
+
+
+    [Fact]
+    public async Task JsonSingleStream_source_to_JsonLine_sink_cross_shape()
+    {
+        // JSON array in, JSONL out — exercises cross-shape composition.
+        var source = new MemoryStream(Encoding.UTF8.GetBytes(
+            System.Text.Json.JsonSerializer.Serialize(People)));
+        var destination = new MemoryStream();
+
+        await EtlPipeline
+            .Create()
+            .JsonSingleStreamExtractor<PersonRecord>(source)
+            .JsonLineLoader<PersonRecord>(destination)
+            .RunAsync();
+
+        destination.Position = 0;
+        var lines = Encoding.UTF8.GetString(destination.ToArray())
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal(3, lines.Length);
+    }
+
+
+    [Fact]
+    public async Task Through_operator_applies_between_json_source_and_sink()
+    {
+        var source = new MemoryStream(Encoding.UTF8.GetBytes(
+            string.Join("\n", People.Select(p => System.Text.Json.JsonSerializer.Serialize(p)))));
+        var destination = new MemoryStream();
+
+        // Keep only people aged 30+ via a stream-to-stream Through stage.
+        await EtlPipeline
+            .Create()
+            .JsonLineExtractor<PersonRecord>(source)
+            .Through<PersonRecord>(items => Filter(items, p => p.Age >= 30))
+            .JsonLineLoader<PersonRecord>(destination)
+            .RunAsync();
+
+        destination.Position = 0;
+        var readBack = new List<PersonRecord>();
+        await foreach (var p in new JsonLineExtractor<PersonRecord>(destination).ExtractAsync())
+        {
+            readBack.Add(p);
+        }
+
+        Assert.Equal(new[] { "Alice", "Carol" }, readBack.Select(p => p.FirstName).ToArray());
+    }
+
+
+    [Fact]
+    public void JsonLineExtractor_null_pipeline_throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => ((EtlPipeline)null!).JsonLineExtractor<PersonRecord>(new MemoryStream()));
+    }
+
+
+    [Fact]
+    public void JsonLineLoader_null_path_throws()
+    {
+        var pipeline = EtlPipeline.Create().JsonLineExtractor<PersonRecord>(new MemoryStream());
+        Assert.Throws<ArgumentNullException>(() => pipeline.JsonLineLoader<PersonRecord>((string)null!));
+    }
+
+
+    private static async IAsyncEnumerable<T> Filter<T>(IAsyncEnumerable<T> items, Func<T, bool> predicate)
+    {
+        await foreach (var item in items)
+        {
+            if (predicate(item))
+            {
+                yield return item;
+            }
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/EtlPipelineJsonExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/EtlPipelineJsonExtensionsTests.cs
@@ -99,7 +99,7 @@ public sealed class EtlPipelineJsonExtensionsTests
 
         destination.Position = 0;
         var lines = Encoding.UTF8.GetString(destination.ToArray())
-            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            .Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
 
         Assert.Equal(3, lines.Length);
     }
@@ -144,6 +144,113 @@ public sealed class EtlPipelineJsonExtensionsTests
     {
         var pipeline = EtlPipeline.Create().JsonLineExtractor<PersonRecord>(new MemoryStream());
         Assert.Throws<ArgumentNullException>(() => pipeline.JsonLineLoader<PersonRecord>((string)null!));
+    }
+
+
+    [Fact]
+    public async Task JsonSingleStream_stream_round_trip_via_pipeline()
+    {
+        var source = new MemoryStream(Encoding.UTF8.GetBytes(
+            System.Text.Json.JsonSerializer.Serialize(People)));
+        var destination = new MemoryStream();
+
+        await EtlPipeline
+            .Create()
+            .JsonSingleStreamExtractor<PersonRecord>(source)
+            .JsonSingleStreamLoader<PersonRecord>(destination)
+            .RunAsync();
+
+        destination.Position = 0;
+        var readBack = await Collect(new JsonSingleStreamExtractor<PersonRecord>(destination).ExtractAsync());
+
+        Assert.Equal(People, readBack);
+    }
+
+
+    [Fact]
+    public async Task JsonSingleStream_file_round_trip_via_pipeline_disposes_streams()
+    {
+        var inPath = Path.GetTempFileName();
+        var outPath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(inPath, System.Text.Json.JsonSerializer.Serialize(People));
+
+            await EtlPipeline
+                .Create()
+                .JsonSingleStreamExtractor<PersonRecord>(inPath)
+                .JsonSingleStreamLoader<PersonRecord>(outPath)
+                .RunAsync();
+
+            // Re-opening the output proves the factory-owned streams were disposed.
+            List<PersonRecord> readBack;
+            using (var outStream = File.OpenRead(outPath))
+            {
+                readBack = await Collect(new JsonSingleStreamExtractor<PersonRecord>(outStream).ExtractAsync());
+            }
+
+            Assert.Equal(People, readBack);
+        }
+        finally
+        {
+            File.Delete(inPath);
+            File.Delete(outPath);
+        }
+    }
+
+
+    [Fact]
+    public async Task Factories_accept_explicit_serializer_options()
+    {
+        var options = new System.Text.Json.JsonSerializerOptions();
+        var source = new MemoryStream(Encoding.UTF8.GetBytes(
+            string.Join("\n", People.Select(p => System.Text.Json.JsonSerializer.Serialize(p, options)))));
+        var destination = new MemoryStream();
+
+        await EtlPipeline
+            .Create()
+            .JsonLineExtractor<PersonRecord>(source, options)
+            .JsonLineLoader<PersonRecord>(destination, options)
+            .RunAsync();
+
+        destination.Position = 0;
+        var readBack = await Collect(new JsonLineExtractor<PersonRecord>(destination).ExtractAsync());
+
+        Assert.Equal(People, readBack);
+    }
+
+
+    [Fact]
+    public void All_factory_null_arguments_throw()
+    {
+        var pipeline = EtlPipeline.Create().JsonLineExtractor<PersonRecord>(new MemoryStream());
+
+        // Source factories.
+        Assert.Throws<ArgumentNullException>(() => ((EtlPipeline)null!).JsonLineExtractor<PersonRecord>("x"));
+        Assert.Throws<ArgumentNullException>(() => EtlPipeline.Create().JsonLineExtractor<PersonRecord>((Stream)null!));
+        Assert.Throws<ArgumentNullException>(() => EtlPipeline.Create().JsonLineExtractor<PersonRecord>((string)null!));
+        Assert.Throws<ArgumentNullException>(() => ((EtlPipeline)null!).JsonSingleStreamExtractor<PersonRecord>("x"));
+        Assert.Throws<ArgumentNullException>(() => EtlPipeline.Create().JsonSingleStreamExtractor<PersonRecord>((Stream)null!));
+        Assert.Throws<ArgumentNullException>(() => EtlPipeline.Create().JsonSingleStreamExtractor<PersonRecord>((string)null!));
+
+        // Sink terminators.
+        Assert.Throws<ArgumentNullException>(() => ((IEtlPipeline<PersonRecord>)null!).JsonLineLoader<PersonRecord>("x"));
+        Assert.Throws<ArgumentNullException>(() => pipeline.JsonLineLoader<PersonRecord>((Stream)null!));
+        Assert.Throws<ArgumentNullException>(() => ((IEtlPipeline<PersonRecord>)null!).JsonSingleStreamLoader<PersonRecord>("x"));
+        Assert.Throws<ArgumentNullException>(() => pipeline.JsonSingleStreamLoader<PersonRecord>((string)null!));
+        Assert.Throws<ArgumentNullException>(() => pipeline.JsonSingleStreamLoader<PersonRecord>((Stream)null!));
+    }
+
+
+    private static async Task<List<T>> Collect<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items)
+        {
+            list.Add(item);
+        }
+
+        return list;
     }
 
 

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonLineExtractorTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonLineExtractorTests.cs
@@ -649,4 +649,135 @@ public class JsonLineExtractorTests
 
         Assert.Equal(item, results[0]);
     }
+
+
+
+    [Fact]
+    public void StartByteOffset_defaults_to_zero()
+    {
+        var sut = new JsonLineExtractor<PersonRecord>(new MemoryStream());
+        Assert.Equal(0, sut.StartByteOffset);
+    }
+
+
+
+    [Fact]
+    public void CurrentByteOffset_is_zero_before_extraction()
+    {
+        var sut = new JsonLineExtractor<PersonRecord>(new MemoryStream());
+        Assert.Equal(0, sut.CurrentByteOffset);
+    }
+
+
+
+    [Fact]
+    public async Task CurrentByteOffset_advances_to_stream_length_after_full_extraction()
+    {
+        var stream = CreateJsonlStream(3);
+        var sut = new JsonLineExtractor<PersonRecord>(stream);
+
+        await sut.ExtractAsync().ToListAsync();
+
+        Assert.Equal(stream.Length, sut.CurrentByteOffset);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_StartByteOffset_set_resumes_from_checkpoint()
+    {
+        var stream = CreateJsonlStream(ExpectedItems.Count);
+
+        // First pass — extract the first two items and capture the checkpoint.
+        var sut1 = new JsonLineExtractor<PersonRecord>(stream)
+        {
+            MaximumItemCount = 2,
+        };
+        var firstBatch = await sut1.ExtractAsync().ToListAsync();
+        var checkpoint = sut1.CurrentByteOffset;
+
+        // Second pass — seek to checkpoint and extract the remainder.
+        var sut2 = new JsonLineExtractor<PersonRecord>(stream)
+        {
+            StartByteOffset = checkpoint,
+        };
+        var secondBatch = await sut2.ExtractAsync().ToListAsync();
+
+        Assert.Equal(ExpectedItems.Take(2).ToList(), firstBatch);
+        Assert.Equal(ExpectedItems.Skip(2).ToList(), secondBatch);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_StartByteOffset_set_extracts_items_from_checkpoint()
+    {
+        var stream = CreateJsonlStream(3);
+        var sut1 = new JsonLineExtractor<PersonRecord>(stream) { MaximumItemCount = 1 };
+        await sut1.ExtractAsync().ToListAsync();
+        var checkpoint = sut1.CurrentByteOffset;
+
+        var sut2 = new JsonLineExtractor<PersonRecord>(stream) { StartByteOffset = checkpoint };
+        var results = await sut2.ExtractAsync().ToListAsync();
+
+        Assert.Equal(ExpectedItems.Skip(1).Take(2).ToList(), results);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_StartByteOffset_non_zero_and_stream_not_seekable_throws()
+    {
+        using var ms = CreateJsonlStream(3);
+        using var nonSeekable = new NonSeekableStream(ms);
+        var sut = new JsonLineExtractor<PersonRecord>(nonSeekable)
+        {
+            StartByteOffset = 10,
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () => await sut.ExtractAsync().ToListAsync()
+        );
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_with_crlf_stream_CurrentByteOffset_advances_to_stream_length()
+    {
+        var lines = ExpectedItems.Take(3).Select(item => JsonSerializer.Serialize(item));
+        var content = string.Join("\r\n", lines);
+        var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+        var sut = new JsonLineExtractor<PersonRecord>(stream);
+
+        await sut.ExtractAsync().ToListAsync();
+
+        Assert.Equal(stream.Length, sut.CurrentByteOffset);
+    }
+
+
+
+    private sealed class NonSeekableStream : Stream
+    {
+        private readonly Stream _inner;
+
+        internal NonSeekableStream(Stream inner) => _inner = inner;
+
+        public override bool CanRead => _inner.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => _inner.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
 }

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonLineExtractorTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonLineExtractorTests.cs
@@ -662,10 +662,34 @@ public class JsonLineExtractorTests
 
 
     [Fact]
-    public void CurrentByteOffset_is_zero_before_extraction()
+    public void EnableCheckpointing_defaults_to_false()
     {
         var sut = new JsonLineExtractor<PersonRecord>(new MemoryStream());
-        Assert.Equal(0, sut.CurrentByteOffset);
+        Assert.False(sut.EnableCheckpointing);
+    }
+
+
+
+    [Fact]
+    public void CurrentByteOffset_throws_when_checkpointing_disabled()
+    {
+        var sut = new JsonLineExtractor<PersonRecord>(new MemoryStream());
+        Assert.Throws<InvalidOperationException>(() => sut.CurrentByteOffset);
+    }
+
+
+
+    [Fact]
+    public async Task CurrentByteOffset_throws_after_extraction_when_checkpointing_disabled()
+    {
+        var stream = CreateJsonlStream(3);
+        var sut = new JsonLineExtractor<PersonRecord>(stream);
+
+        var results = await sut.ExtractAsync().ToListAsync();
+
+        // Extraction still works with checkpointing off; only CurrentByteOffset is unavailable.
+        Assert.Equal(3, results.Count);
+        Assert.Throws<InvalidOperationException>(() => sut.CurrentByteOffset);
     }
 
 
@@ -674,7 +698,10 @@ public class JsonLineExtractorTests
     public async Task CurrentByteOffset_advances_to_stream_length_after_full_extraction()
     {
         var stream = CreateJsonlStream(3);
-        var sut = new JsonLineExtractor<PersonRecord>(stream);
+        var sut = new JsonLineExtractor<PersonRecord>(stream)
+        {
+            EnableCheckpointing = true,
+        };
 
         await sut.ExtractAsync().ToListAsync();
 
@@ -692,11 +719,13 @@ public class JsonLineExtractorTests
         var sut1 = new JsonLineExtractor<PersonRecord>(stream)
         {
             MaximumItemCount = 2,
+            EnableCheckpointing = true,
         };
         var firstBatch = await sut1.ExtractAsync().ToListAsync();
         var checkpoint = sut1.CurrentByteOffset;
 
         // Second pass — seek to checkpoint and extract the remainder.
+        // Resuming via StartByteOffset works even without EnableCheckpointing.
         var sut2 = new JsonLineExtractor<PersonRecord>(stream)
         {
             StartByteOffset = checkpoint,
@@ -713,7 +742,7 @@ public class JsonLineExtractorTests
     public async Task ExtractAsync_when_StartByteOffset_set_extracts_items_from_checkpoint()
     {
         var stream = CreateJsonlStream(3);
-        var sut1 = new JsonLineExtractor<PersonRecord>(stream) { MaximumItemCount = 1 };
+        var sut1 = new JsonLineExtractor<PersonRecord>(stream) { MaximumItemCount = 1, EnableCheckpointing = true };
         await sut1.ExtractAsync().ToListAsync();
         var checkpoint = sut1.CurrentByteOffset;
 
@@ -749,7 +778,10 @@ public class JsonLineExtractorTests
         var lines = ExpectedItems.Take(3).Select(item => JsonSerializer.Serialize(item));
         var content = string.Join("\r\n", lines);
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
-        var sut = new JsonLineExtractor<PersonRecord>(stream);
+        var sut = new JsonLineExtractor<PersonRecord>(stream)
+        {
+            EnableCheckpointing = true,
+        };
 
         await sut.ExtractAsync().ToListAsync();
 

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMetricsTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMetricsTests.cs
@@ -27,10 +27,8 @@ public sealed class JsonMetricsTests
     private sealed class MetricsCollector : IDisposable
     {
         private readonly MeterListener _listener = new();
-
-        public List<string> Counters { get; } = new();
-
-        public List<string> Histograms { get; } = new();
+        private readonly List<string> _counters = new();
+        private readonly List<string> _histograms = new();
 
         public MetricsCollector()
         {
@@ -44,21 +42,40 @@ public sealed class JsonMetricsTests
 
             _listener.SetMeasurementEventCallback<long>((instrument, _, _, _) =>
             {
-                lock (Counters)
+                lock (_counters)
                 {
-                    Counters.Add(instrument.Name);
+                    _counters.Add(instrument.Name);
                 }
             });
 
             _listener.SetMeasurementEventCallback<double>((instrument, _, _, _) =>
             {
-                lock (Histograms)
+                lock (_histograms)
                 {
-                    Histograms.Add(instrument.Name);
+                    _histograms.Add(instrument.Name);
                 }
             });
 
             _listener.Start();
+        }
+
+        // Reads must hold the same lock as the callbacks' writes: the listener fires on other
+        // threads (including measurements from tests running in parallel), so an unlocked
+        // enumeration can race with an Add and throw "Collection was modified".
+        public bool CounterRecorded(string name)
+        {
+            lock (_counters)
+            {
+                return _counters.Contains(name);
+            }
+        }
+
+        public bool HistogramRecorded(string name)
+        {
+            lock (_histograms)
+            {
+                return _histograms.Contains(name);
+            }
         }
 
         public void Dispose() => _listener.Dispose();
@@ -79,9 +96,9 @@ public sealed class JsonMetricsTests
         {
         }
 
-        Assert.Contains("wolfgang.etl.json.items.extracted", collector.Counters);
-        Assert.Contains("wolfgang.etl.json.items.skipped", collector.Counters);
-        Assert.Contains("wolfgang.etl.json.operation.duration", collector.Histograms);
+        Assert.True(collector.CounterRecorded("wolfgang.etl.json.items.extracted"));
+        Assert.True(collector.CounterRecorded("wolfgang.etl.json.items.skipped"));
+        Assert.True(collector.HistogramRecorded("wolfgang.etl.json.operation.duration"));
     }
 
 
@@ -93,8 +110,8 @@ public sealed class JsonMetricsTests
 
         await loader.LoadAsync(Source());
 
-        Assert.Contains("wolfgang.etl.json.items.loaded", collector.Counters);
-        Assert.Contains("wolfgang.etl.json.operation.duration", collector.Histograms);
+        Assert.True(collector.CounterRecorded("wolfgang.etl.json.items.loaded"));
+        Assert.True(collector.HistogramRecorded("wolfgang.etl.json.operation.duration"));
     }
 
 

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMetricsTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMetricsTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Json.Tests.Unit.TestModels;
+using Xunit;
+
+namespace Wolfgang.Etl.Json.Tests.Unit;
+
+public sealed class JsonMetricsTests
+{
+    private static readonly PersonRecord[] People =
+    {
+        new() { FirstName = "Alice", LastName = "Smith", Age = 30 },
+        new() { FirstName = "Bob", LastName = "Jones", Age = 25 },
+        new() { FirstName = "Carol", LastName = "White", Age = 35 },
+    };
+
+
+    // Subscribes to the Wolfgang.Etl.Json meter and records which instruments fired. When a
+    // listener is attached the extractors/loaders' Instrument.Enabled guards are true, so the
+    // Counter.Add / Histogram.Record calls execute.
+    private sealed class MetricsCollector : IDisposable
+    {
+        private readonly MeterListener _listener = new();
+
+        public List<string> Counters { get; } = new();
+
+        public List<string> Histograms { get; } = new();
+
+        public MetricsCollector()
+        {
+            _listener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (string.Equals(instrument.Meter.Name, "Wolfgang.Etl.Json", StringComparison.Ordinal))
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+
+            _listener.SetMeasurementEventCallback<long>((instrument, _, _, _) =>
+            {
+                lock (Counters)
+                {
+                    Counters.Add(instrument.Name);
+                }
+            });
+
+            _listener.SetMeasurementEventCallback<double>((instrument, _, _, _) =>
+            {
+                lock (Histograms)
+                {
+                    Histograms.Add(instrument.Name);
+                }
+            });
+
+            _listener.Start();
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+
+    private static MemoryStream JsonlStream() =>
+        new(Encoding.UTF8.GetBytes(string.Join("\n", People.Select(p => JsonSerializer.Serialize(p)))));
+
+
+    [Fact]
+    public async Task Extractor_emits_extracted_skipped_and_duration_metrics_when_a_listener_is_subscribed()
+    {
+        using var collector = new MetricsCollector();
+        var sut = new JsonLineExtractor<PersonRecord>(JsonlStream()) { SkipItemCount = 1 };
+
+        await foreach (var _ in sut.ExtractAsync())
+        {
+        }
+
+        Assert.Contains("wolfgang.etl.json.items.extracted", collector.Counters);
+        Assert.Contains("wolfgang.etl.json.items.skipped", collector.Counters);
+        Assert.Contains("wolfgang.etl.json.operation.duration", collector.Histograms);
+    }
+
+
+    [Fact]
+    public async Task Loader_emits_loaded_and_duration_metrics_when_a_listener_is_subscribed()
+    {
+        using var collector = new MetricsCollector();
+        var loader = new JsonLineLoader<PersonRecord>(new MemoryStream());
+
+        await loader.LoadAsync(Source());
+
+        Assert.Contains("wolfgang.etl.json.items.loaded", collector.Counters);
+        Assert.Contains("wolfgang.etl.json.operation.duration", collector.Histograms);
+    }
+
+
+    private static async IAsyncEnumerable<PersonRecord> Source()
+    {
+        foreach (var person in People)
+        {
+            await Task.Yield();
+            yield return person;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Cuts the **v0.5.0** release to `main`. Bundles the vNext integration work for this cycle.

### Features
| Feature | Issue | PR |
|---|---|---|
| Checkpoint/resume for `JsonLineExtractor` (`StartByteOffset` / `CurrentByteOffset`) | #16 | #238 |
| OpenTelemetry metrics (`System.Diagnostics.Metrics`) across all extractors/loaders | #14 | #237 |

### Docs
- Advanced Usage README section (#17, #18) — compressed streams + schema customization guides

### Release metadata
- `<Version>` 0.4.0 → 0.5.0 (MINOR — additive public API, no breaking changes)
- CHANGELOG `[0.5.0]` entry + backfilled `[0.4.0]` + fixed compare-link footer (#240)

## Bump rationale

MINOR: two new public-API surfaces (`StartByteOffset`/`CurrentByteOffset`, the metrics meter/instruments), zero breaking changes. `AssemblyVersion` stays pinned at `1.0.0.0` for binding stability.

## Test plan

- [x] `dotnet test -c Release` green across all TFMs (432 unit + 12 integration per TFM)
- [ ] CI Stage 1/2/3 + Detect .NET Projects green on this PR

After merge: tag `v0.5.0` on main to fire `release.yaml` (NuGet publish + docs deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)