### PR TITLE
perf: make byte-tracking opt-in (EnableCheckpointing) + gate metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Checkpoint/resume support on `JsonLineExtractor<TRecord>`: new `StartByteOffset` (settable) and
-  `CurrentByteOffset` (read-only) properties. Capture `CurrentByteOffset` after each yielded item to
-  record a byte-position checkpoint, then set `StartByteOffset` on a fresh extractor to resume from
-  that position. The stream must be seekable when `StartByteOffset` is greater than zero. Line
-  endings (`\n` vs `\r\n`) are detected automatically. Closes #16.
+- Checkpoint/resume support on `JsonLineExtractor<TRecord>`: new `EnableCheckpointing` (settable,
+  default `false`), `StartByteOffset` (settable) and `CurrentByteOffset` (read-only) properties. Set
+  `EnableCheckpointing` to `true`, then capture `CurrentByteOffset` after each yielded item to record
+  a byte-position checkpoint; set `StartByteOffset` on a fresh extractor to resume from that position.
+  Byte tracking is opt-in because it adds per-line overhead on the extraction hot path — with
+  `EnableCheckpointing` left `false` (the default) there is no cost, and reading `CurrentByteOffset`
+  throws `InvalidOperationException`. Resuming via `StartByteOffset` does not itself require the flag.
+  The stream must be seekable when `StartByteOffset` is greater than zero. Line endings (`\n` vs
+  `\r\n`) are detected automatically. Closes #16.
 - Built-in OpenTelemetry metrics via `System.Diagnostics.Metrics`. All extractors and loaders emit
   counters (`wolfgang.etl.json.items.extracted`, `.items.loaded`, `.items.skipped`) and an operation
   duration histogram (`wolfgang.etl.json.operation.duration`) under the `Wolfgang.Etl.Json` meter,

--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -63,6 +63,22 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
 
 
     /// <summary>
+    /// Gets or sets a value indicating whether the extractor tracks the byte offset of each line
+    /// so that <see cref="CurrentByteOffset"/> can be captured as a resumable checkpoint.
+    /// Default is <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// Tracking requires computing the byte length of every line, which adds measurable per-line
+    /// overhead on the extraction hot path. It is therefore opt-in: leave this <see langword="false"/>
+    /// unless you intend to read <see cref="CurrentByteOffset"/> to create checkpoints. Resuming a
+    /// prior run via <see cref="StartByteOffset"/> does not by itself require this flag — set it only
+    /// when you also need to capture new checkpoints during the resumed run.
+    /// </remarks>
+    public bool EnableCheckpointing { get; set; }
+
+
+
+    /// <summary>
     /// Gets or sets the byte offset within the stream at which extraction begins.
     /// Set this before calling <see cref="ExtractorBase{TSource,TProgress}.ExtractAsync(System.Threading.CancellationToken)"/> to resume from a saved checkpoint.
     /// The stream must be seekable when this value is greater than zero.
@@ -76,7 +92,14 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
     /// Gets the byte offset of the start of the next unread line in the stream.
     /// Capture this value after each <see langword="yield"/> to create a resumable checkpoint.
     /// </summary>
-    public long CurrentByteOffset => Interlocked.Read(ref _currentByteOffset);
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="EnableCheckpointing"/> is <see langword="false"/>. Byte offsets are
+    /// only tracked when checkpointing is enabled.
+    /// </exception>
+    public long CurrentByteOffset =>
+        EnableCheckpointing
+            ? Interlocked.Read(ref _currentByteOffset)
+            : throw new InvalidOperationException("Set EnableCheckpointing to true before reading CurrentByteOffset.");
 
 
 
@@ -272,6 +295,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
     {
         _errors.Clear();
         JsonLogMessages.StartingOperation(_logger, OperationName, null);
+        var track = EnableCheckpointing;
         var (newlineSize, lineEncoding) = await PrepareForExtractionAsync(token).ConfigureAwait(false);
         var skipBudget = SkipItemCount;
         var sw = Stopwatch.StartNew();
@@ -284,7 +308,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
 #endif
         {
             token.ThrowIfCancellationRequested();
-            var lineBytes = lineEncoding.GetByteCount(line) + newlineSize;
+            var lineBytes = track ? lineEncoding.GetByteCount(line) + newlineSize : 0;
             var lineNum = Interlocked.Increment(ref _currentLineNumber);
             if (string.IsNullOrWhiteSpace(line))
             {
@@ -348,7 +372,9 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
         Interlocked.Exchange(ref _currentLineNumber, 0);
         Interlocked.Exchange(ref _currentByteOffset, StartByteOffset);
         var lineEncoding = Encoding ?? System.Text.Encoding.UTF8;
-        var newlineSize = await DetectNewlineSizeAsync(token).ConfigureAwait(false);
+        var newlineSize = EnableCheckpointing
+            ? await DetectNewlineSizeAsync(token).ConfigureAwait(false)
+            : 0;
         if (StartByteOffset > 0)
         {
             if (!_stream.CanSeek)

--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -309,7 +309,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
                 skipBudget--;
                 Interlocked.Add(ref _currentByteOffset, lineBytes);
                 IncrementCurrentSkippedItemCount();
-                JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                JsonMetrics.AddSkipped(_operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.SkippedItemAtLine(_logger, CurrentSkippedItemCount, SkipItemCount, lineNum, null);
                 continue;
             }
@@ -320,7 +320,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
             }
             Interlocked.Add(ref _currentByteOffset, lineBytes);
             IncrementCurrentItemCount();
-            JsonMetrics.ItemsExtracted.Add(1, _operationTag, _componentTag, _recordTypeTag);
+            JsonMetrics.AddExtracted(_operationTag, _componentTag, _recordTypeTag);
             JsonLogMessages.ExtractedItemFromLine(_logger, CurrentItemCount, lineNum, null);
             yield return item;
         }
@@ -338,7 +338,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
         }
 
         JsonLogMessages.JsonlExtractionCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, Interlocked.Read(ref _currentLineNumber), null);
-        JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
+        JsonMetrics.RecordDuration(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
     }
 
 

--- a/src/Wolfgang.Etl.Json/JsonLineLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineLoader.cs
@@ -236,7 +236,7 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>, I
             if (CurrentSkippedItemCount < SkipItemCount)
             {
                 IncrementCurrentSkippedItemCount();
-                JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                JsonMetrics.AddSkipped(_operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
                 continue;
             }
@@ -272,12 +272,12 @@ public sealed class JsonLineLoader<TRecord> : LoaderBase<TRecord, JsonReport>, I
             }
 
             IncrementCurrentItemCount();
-            JsonMetrics.ItemsLoaded.Add(1, _operationTag, _componentTag, _recordTypeTag);
+            JsonMetrics.AddLoaded(_operationTag, _componentTag, _recordTypeTag);
             JsonLogMessages.LoadedItemAtLine(_logger, CurrentItemCount, Interlocked.Read(ref _currentLineNumber), null);
         }
 
         JsonLogMessages.JsonlLoadingCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, Interlocked.Read(ref _currentLineNumber), null);
-        JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
+        JsonMetrics.RecordDuration(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
     }
 
 

--- a/src/Wolfgang.Etl.Json/JsonMetrics.cs
+++ b/src/Wolfgang.Etl.Json/JsonMetrics.cs
@@ -34,4 +34,79 @@ internal static class JsonMetrics
             "wolfgang.etl.json.operation.duration",
             unit: "ms",
             description: "Duration of extract/load operations in milliseconds.");
+
+
+
+    /// <summary>
+    /// Records one extracted item. The <see cref="Instrument.Enabled"/> guard skips the
+    /// diagnostics machinery entirely when no listener is subscribed, keeping the hot path free.
+    /// </summary>
+    internal static void AddExtracted
+    (
+        KeyValuePair<string, object?> operation,
+        KeyValuePair<string, object?> component,
+        KeyValuePair<string, object?> recordType
+    )
+    {
+        if (ItemsExtracted.Enabled)
+        {
+            ItemsExtracted.Add(1, operation, component, recordType);
+        }
+    }
+
+
+
+    /// <summary>
+    /// Records one loaded item. See <see cref="AddExtracted"/> for the enabled-guard rationale.
+    /// </summary>
+    internal static void AddLoaded
+    (
+        KeyValuePair<string, object?> operation,
+        KeyValuePair<string, object?> component,
+        KeyValuePair<string, object?> recordType
+    )
+    {
+        if (ItemsLoaded.Enabled)
+        {
+            ItemsLoaded.Add(1, operation, component, recordType);
+        }
+    }
+
+
+
+    /// <summary>
+    /// Records one skipped item. See <see cref="AddExtracted"/> for the enabled-guard rationale.
+    /// </summary>
+    internal static void AddSkipped
+    (
+        KeyValuePair<string, object?> operation,
+        KeyValuePair<string, object?> component,
+        KeyValuePair<string, object?> recordType
+    )
+    {
+        if (ItemsSkipped.Enabled)
+        {
+            ItemsSkipped.Add(1, operation, component, recordType);
+        }
+    }
+
+
+
+    /// <summary>
+    /// Records an operation's duration in milliseconds. See <see cref="AddExtracted"/> for the
+    /// enabled-guard rationale.
+    /// </summary>
+    internal static void RecordDuration
+    (
+        double milliseconds,
+        KeyValuePair<string, object?> operation,
+        KeyValuePair<string, object?> component,
+        KeyValuePair<string, object?> recordType
+    )
+    {
+        if (OperationDuration.Enabled)
+        {
+            OperationDuration.Record(milliseconds, operation, component, recordType);
+        }
+    }
 }

--- a/src/Wolfgang.Etl.Json/JsonMultiStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonMultiStreamExtractor.cs
@@ -411,7 +411,7 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
                 {
                     skipBudget--;
                     IncrementCurrentSkippedItemCount();
-                    JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                    JsonMetrics.AddSkipped(_operationTag, _componentTag, _recordTypeTag);
                     JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
                     continue;
                 }
@@ -423,7 +423,7 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
                 }
 
                 IncrementCurrentItemCount();
-                JsonMetrics.ItemsExtracted.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                JsonMetrics.AddExtracted(_operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.ExtractedItemFromStream(_logger, CurrentItemCount, streamIndex - 1, null);
 
                 yield return item;
@@ -433,7 +433,7 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
         }
         finally
         {
-            JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
+            JsonMetrics.RecordDuration(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
         }
     }
 

--- a/src/Wolfgang.Etl.Json/JsonMultiStreamLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonMultiStreamLoader.cs
@@ -409,7 +409,7 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
                 if (CurrentSkippedItemCount < SkipItemCount)
                 {
                     IncrementCurrentSkippedItemCount();
-                    JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                    JsonMetrics.AddSkipped(_operationTag, _componentTag, _recordTypeTag);
                     JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
                     continue;
                 }
@@ -424,7 +424,7 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
                 {
                     _currentDestinationName = null;
                     IncrementCurrentItemCount();
-                    JsonMetrics.ItemsLoaded.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                    JsonMetrics.AddLoaded(_operationTag, _componentTag, _recordTypeTag);
                     streamIndex++;
                     JsonLogMessages.LoadedItemToStream(_logger, CurrentItemCount, streamIndex - 1, null);
                     continue;
@@ -439,7 +439,7 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
                 }
                 await WriteItemToStreamAsync(destination.Stream, item, streamIndex, token).ConfigureAwait(false);
                 IncrementCurrentItemCount();
-                JsonMetrics.ItemsLoaded.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                JsonMetrics.AddLoaded(_operationTag, _componentTag, _recordTypeTag);
                 streamIndex++;
                 JsonLogMessages.LoadedItemToStream(_logger, CurrentItemCount, streamIndex - 1, null);
             }
@@ -448,7 +448,7 @@ public sealed class JsonMultiStreamLoader<TRecord> : LoaderBase<TRecord, JsonRep
         }
         finally
         {
-            JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
+            JsonMetrics.RecordDuration(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
         }
     }
 

--- a/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
@@ -267,7 +267,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
                 {
                     skipBudget--;
                     IncrementCurrentSkippedItemCount();
-                    JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                    JsonMetrics.AddSkipped(_operationTag, _componentTag, _recordTypeTag);
                     JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
                     continue;
                 }
@@ -277,7 +277,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
                     break;
                 }
                 IncrementCurrentItemCount();
-                JsonMetrics.ItemsExtracted.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                JsonMetrics.AddExtracted(_operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.ExtractedItem(_logger, CurrentItemCount, null);
                 yield return item;
             }
@@ -285,7 +285,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
         finally
         {
             await enumerator.DisposeAsync().ConfigureAwait(false);
-            JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
+            JsonMetrics.RecordDuration(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
         }
 
         JsonLogMessages.SingleStreamExtractionCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, null);

--- a/src/Wolfgang.Etl.Json/JsonSingleStreamLoader.cs
+++ b/src/Wolfgang.Etl.Json/JsonSingleStreamLoader.cs
@@ -231,7 +231,7 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
             if (CurrentSkippedItemCount < SkipItemCount)
             {
                 IncrementCurrentSkippedItemCount();
-                JsonMetrics.ItemsSkipped.Add(1, _operationTag, _componentTag, _recordTypeTag);
+                JsonMetrics.AddSkipped(_operationTag, _componentTag, _recordTypeTag);
                 JsonLogMessages.SkippedItem(_logger, CurrentSkippedItemCount, SkipItemCount, null);
                 continue;
             }
@@ -255,7 +255,7 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
             }
 
             IncrementCurrentItemCount();
-            JsonMetrics.ItemsLoaded.Add(1, _operationTag, _componentTag, _recordTypeTag);
+            JsonMetrics.AddLoaded(_operationTag, _componentTag, _recordTypeTag);
             JsonLogMessages.LoadedItem(_logger, CurrentItemCount, null);
         }
 
@@ -266,7 +266,7 @@ public sealed class JsonSingleStreamLoader<TRecord> : LoaderBase<TRecord, JsonRe
         }
 
         JsonLogMessages.SingleStreamLoadingCompleted(_logger, CurrentItemCount, CurrentSkippedItemCount, null);
-        JsonMetrics.OperationDuration.Record(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
+        JsonMetrics.RecordDuration(sw.Elapsed.TotalMilliseconds, _operationTag, _componentTag, _recordTypeTag);
     }
 
 

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonLineExtractorTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonLineExtractorTests.cs
@@ -662,10 +662,34 @@ public class JsonLineExtractorTests
 
 
     [Fact]
-    public void CurrentByteOffset_is_zero_before_extraction()
+    public void EnableCheckpointing_defaults_to_false()
     {
         var sut = new JsonLineExtractor<PersonRecord>(new MemoryStream());
-        Assert.Equal(0, sut.CurrentByteOffset);
+        Assert.False(sut.EnableCheckpointing);
+    }
+
+
+
+    [Fact]
+    public void CurrentByteOffset_throws_when_checkpointing_disabled()
+    {
+        var sut = new JsonLineExtractor<PersonRecord>(new MemoryStream());
+        Assert.Throws<InvalidOperationException>(() => sut.CurrentByteOffset);
+    }
+
+
+
+    [Fact]
+    public async Task CurrentByteOffset_throws_after_extraction_when_checkpointing_disabled()
+    {
+        var stream = CreateJsonlStream(3);
+        var sut = new JsonLineExtractor<PersonRecord>(stream);
+
+        var results = await sut.ExtractAsync().ToListAsync();
+
+        // Extraction still works with checkpointing off; only CurrentByteOffset is unavailable.
+        Assert.Equal(3, results.Count);
+        Assert.Throws<InvalidOperationException>(() => sut.CurrentByteOffset);
     }
 
 
@@ -674,7 +698,10 @@ public class JsonLineExtractorTests
     public async Task CurrentByteOffset_advances_to_stream_length_after_full_extraction()
     {
         var stream = CreateJsonlStream(3);
-        var sut = new JsonLineExtractor<PersonRecord>(stream);
+        var sut = new JsonLineExtractor<PersonRecord>(stream)
+        {
+            EnableCheckpointing = true,
+        };
 
         await sut.ExtractAsync().ToListAsync();
 
@@ -692,11 +719,13 @@ public class JsonLineExtractorTests
         var sut1 = new JsonLineExtractor<PersonRecord>(stream)
         {
             MaximumItemCount = 2,
+            EnableCheckpointing = true,
         };
         var firstBatch = await sut1.ExtractAsync().ToListAsync();
         var checkpoint = sut1.CurrentByteOffset;
 
         // Second pass — seek to checkpoint and extract the remainder.
+        // Resuming via StartByteOffset works even without EnableCheckpointing.
         var sut2 = new JsonLineExtractor<PersonRecord>(stream)
         {
             StartByteOffset = checkpoint,
@@ -713,7 +742,7 @@ public class JsonLineExtractorTests
     public async Task ExtractAsync_when_StartByteOffset_set_extracts_items_from_checkpoint()
     {
         var stream = CreateJsonlStream(3);
-        var sut1 = new JsonLineExtractor<PersonRecord>(stream) { MaximumItemCount = 1 };
+        var sut1 = new JsonLineExtractor<PersonRecord>(stream) { MaximumItemCount = 1, EnableCheckpointing = true };
         await sut1.ExtractAsync().ToListAsync();
         var checkpoint = sut1.CurrentByteOffset;
 
@@ -749,7 +778,10 @@ public class JsonLineExtractorTests
         var lines = ExpectedItems.Take(3).Select(item => JsonSerializer.Serialize(item));
         var content = string.Join("\r\n", lines);
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
-        var sut = new JsonLineExtractor<PersonRecord>(stream);
+        var sut = new JsonLineExtractor<PersonRecord>(stream)
+        {
+            EnableCheckpointing = true,
+        };
 
         await sut.ExtractAsync().ToListAsync();
 


### PR DESCRIPTION
## Summary

Removes the BDN regression flagged on the v0.5.0 release PR (#241): `JsonLineExtractor.ExtractAsync(1000)` was **+21.4%** vs `main`.

Investigation (via #242's first commit) showed the metric emission was *not* the cost — with precomputed static tags, `Counter.Add` under no listener was already cheap. The real driver was **`Encoding.GetByteCount(line)` running per line on every JSONL extract**, including for the majority of users who never checkpoint.

### Fix: opt-in byte tracking
- New `EnableCheckpointing` property on `JsonLineExtractor<TRecord>` (settable, **default `false`**).
- When `false` (the default and the benchmark's path): the per-line byte count and newline detection are skipped entirely — zero added cost vs 0.4.0. Reading `CurrentByteOffset` throws `InvalidOperationException`.
- When `true`: full checkpoint tracking as before.
- **Resuming** via `StartByteOffset` still works without the flag (it only seeks); the flag is needed only to *produce* new checkpoints.

### Also kept: metric `Enabled` guards
- All 19 `Counter.Add`/`Histogram.Record` sites route through `JsonMetrics` helpers gated on `Instrument.Enabled`. Low impact at rest, but correct hygiene and cheaper under heavy listener load. No behavior change when a listener is attached.

## API / SemVer
Still MINOR for 0.5.0 — `EnableCheckpointing` is additive. `CurrentByteOffset` now throwing when disabled is a refinement of an unreleased-this-cycle property (0.5.0 not yet tagged), not a break to any shipped API.

## Test plan
- [x] `dotnet build -c Release` clean
- [x] Unit tests green (434; checkpoint tests updated to set `EnableCheckpointing`, new tests for the default-off throw behavior)
- [ ] #242 BDN vs vNext
- [ ] **#241 BDN vs main back under 20%** once this merges to vNext

## CHANGELOG
0.5.0 entry updated to document `EnableCheckpointing` and the opt-in rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)