### PR TITLE
test: cover JsonMetrics emission to fix the 90% coverage gate

### DIFF
--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMetricsTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMetricsTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Json.Tests.Unit.TestModels;
+using Xunit;
+
+namespace Wolfgang.Etl.Json.Tests.Unit;
+
+public sealed class JsonMetricsTests
+{
+    private static readonly PersonRecord[] People =
+    {
+        new() { FirstName = "Alice", LastName = "Smith", Age = 30 },
+        new() { FirstName = "Bob", LastName = "Jones", Age = 25 },
+        new() { FirstName = "Carol", LastName = "White", Age = 35 },
+    };
+
+
+    // Subscribes to the Wolfgang.Etl.Json meter and records which instruments fired. When a
+    // listener is attached the extractors/loaders' Instrument.Enabled guards are true, so the
+    // Counter.Add / Histogram.Record calls execute.
+    private sealed class MetricsCollector : IDisposable
+    {
+        private readonly MeterListener _listener = new();
+
+        public List<string> Counters { get; } = new();
+
+        public List<string> Histograms { get; } = new();
+
+        public MetricsCollector()
+        {
+            _listener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (string.Equals(instrument.Meter.Name, "Wolfgang.Etl.Json", StringComparison.Ordinal))
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+
+            _listener.SetMeasurementEventCallback<long>((instrument, _, _, _) =>
+            {
+                lock (Counters)
+                {
+                    Counters.Add(instrument.Name);
+                }
+            });
+
+            _listener.SetMeasurementEventCallback<double>((instrument, _, _, _) =>
+            {
+                lock (Histograms)
+                {
+                    Histograms.Add(instrument.Name);
+                }
+            });
+
+            _listener.Start();
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+
+    private static MemoryStream JsonlStream() =>
+        new(Encoding.UTF8.GetBytes(string.Join("\n", People.Select(p => JsonSerializer.Serialize(p)))));
+
+
+    [Fact]
+    public async Task Extractor_emits_extracted_skipped_and_duration_metrics_when_a_listener_is_subscribed()
+    {
+        using var collector = new MetricsCollector();
+        var sut = new JsonLineExtractor<PersonRecord>(JsonlStream()) { SkipItemCount = 1 };
+
+        await foreach (var _ in sut.ExtractAsync())
+        {
+        }
+
+        Assert.Contains("wolfgang.etl.json.items.extracted", collector.Counters);
+        Assert.Contains("wolfgang.etl.json.items.skipped", collector.Counters);
+        Assert.Contains("wolfgang.etl.json.operation.duration", collector.Histograms);
+    }
+
+
+    [Fact]
+    public async Task Loader_emits_loaded_and_duration_metrics_when_a_listener_is_subscribed()
+    {
+        using var collector = new MetricsCollector();
+        var loader = new JsonLineLoader<PersonRecord>(new MemoryStream());
+
+        await loader.LoadAsync(Source());
+
+        Assert.Contains("wolfgang.etl.json.items.loaded", collector.Counters);
+        Assert.Contains("wolfgang.etl.json.operation.duration", collector.Histograms);
+    }
+
+
+    private static async IAsyncEnumerable<PersonRecord> Source()
+    {
+        foreach (var person in People)
+        {
+            await Task.Yield();
+            yield return person;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Unblocks the **v0.5.0 release** (#241), which was failing Stage 1's coverage gate on a single module: **`JsonMetrics` at 87%** (threshold 90%).

Root cause: there were no metrics tests, so the helpers' `Instrument.Enabled` guards were only ever hit with **no listener attached** (`Enabled == false`) — the `Counter.Add` / `Histogram.Record` lines inside the guards were never executed.

This adds `JsonMetricsTests`, which subscribe a `MeterListener` to the `Wolfgang.Etl.Json` meter and assert all four instruments fire:
- extractor run (with `SkipItemCount`) → `items.extracted` + `items.skipped` + `operation.duration`
- loader run → `items.loaded` + `operation.duration`

## Result
- **`JsonMetrics` coverage 87% → 100%** (verified locally: cobertura `line-rate="1"`).
- Test-only change; no production code touched.

## Test plan
- [x] Both new tests pass (net8.0)
- [x] JsonMetrics at 100% line coverage locally
- [ ] Stage 1 coverage gate green on vNext / #241

Once merged into vNext, #241 (release: v0.5.0) re-runs and the coverage gate clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)