### PR TITLE
fix: JsonSingleStreamLoader(Stream) stream-ownership bug + net-fx test compat + #62 coverage

### DIFF
--- a/src/Wolfgang.Etl.Json/EtlPipelineJsonSinkExtensions.cs
+++ b/src/Wolfgang.Etl.Json/EtlPipelineJsonSinkExtensions.cs
@@ -167,6 +167,6 @@ public static class EtlPipelineJsonSinkExtensions
         var loader = options is null
             ? new JsonSingleStreamLoader<T>(stream)
             : new JsonSingleStreamLoader<T>(stream, options);
-        return pipeline.To(loader).DisposingOwned(stream);
+        return pipeline.To(loader);
     }
 }

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/EtlPipelineJsonExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/EtlPipelineJsonExtensionsTests.cs
@@ -99,7 +99,7 @@ public sealed class EtlPipelineJsonExtensionsTests
 
         destination.Position = 0;
         var lines = Encoding.UTF8.GetString(destination.ToArray())
-            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            .Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
 
         Assert.Equal(3, lines.Length);
     }
@@ -144,6 +144,113 @@ public sealed class EtlPipelineJsonExtensionsTests
     {
         var pipeline = EtlPipeline.Create().JsonLineExtractor<PersonRecord>(new MemoryStream());
         Assert.Throws<ArgumentNullException>(() => pipeline.JsonLineLoader<PersonRecord>((string)null!));
+    }
+
+
+    [Fact]
+    public async Task JsonSingleStream_stream_round_trip_via_pipeline()
+    {
+        var source = new MemoryStream(Encoding.UTF8.GetBytes(
+            System.Text.Json.JsonSerializer.Serialize(People)));
+        var destination = new MemoryStream();
+
+        await EtlPipeline
+            .Create()
+            .JsonSingleStreamExtractor<PersonRecord>(source)
+            .JsonSingleStreamLoader<PersonRecord>(destination)
+            .RunAsync();
+
+        destination.Position = 0;
+        var readBack = await Collect(new JsonSingleStreamExtractor<PersonRecord>(destination).ExtractAsync());
+
+        Assert.Equal(People, readBack);
+    }
+
+
+    [Fact]
+    public async Task JsonSingleStream_file_round_trip_via_pipeline_disposes_streams()
+    {
+        var inPath = Path.GetTempFileName();
+        var outPath = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(inPath, System.Text.Json.JsonSerializer.Serialize(People));
+
+            await EtlPipeline
+                .Create()
+                .JsonSingleStreamExtractor<PersonRecord>(inPath)
+                .JsonSingleStreamLoader<PersonRecord>(outPath)
+                .RunAsync();
+
+            // Re-opening the output proves the factory-owned streams were disposed.
+            List<PersonRecord> readBack;
+            using (var outStream = File.OpenRead(outPath))
+            {
+                readBack = await Collect(new JsonSingleStreamExtractor<PersonRecord>(outStream).ExtractAsync());
+            }
+
+            Assert.Equal(People, readBack);
+        }
+        finally
+        {
+            File.Delete(inPath);
+            File.Delete(outPath);
+        }
+    }
+
+
+    [Fact]
+    public async Task Factories_accept_explicit_serializer_options()
+    {
+        var options = new System.Text.Json.JsonSerializerOptions();
+        var source = new MemoryStream(Encoding.UTF8.GetBytes(
+            string.Join("\n", People.Select(p => System.Text.Json.JsonSerializer.Serialize(p, options)))));
+        var destination = new MemoryStream();
+
+        await EtlPipeline
+            .Create()
+            .JsonLineExtractor<PersonRecord>(source, options)
+            .JsonLineLoader<PersonRecord>(destination, options)
+            .RunAsync();
+
+        destination.Position = 0;
+        var readBack = await Collect(new JsonLineExtractor<PersonRecord>(destination).ExtractAsync());
+
+        Assert.Equal(People, readBack);
+    }
+
+
+    [Fact]
+    public void All_factory_null_arguments_throw()
+    {
+        var pipeline = EtlPipeline.Create().JsonLineExtractor<PersonRecord>(new MemoryStream());
+
+        // Source factories.
+        Assert.Throws<ArgumentNullException>(() => ((EtlPipeline)null!).JsonLineExtractor<PersonRecord>("x"));
+        Assert.Throws<ArgumentNullException>(() => EtlPipeline.Create().JsonLineExtractor<PersonRecord>((Stream)null!));
+        Assert.Throws<ArgumentNullException>(() => EtlPipeline.Create().JsonLineExtractor<PersonRecord>((string)null!));
+        Assert.Throws<ArgumentNullException>(() => ((EtlPipeline)null!).JsonSingleStreamExtractor<PersonRecord>("x"));
+        Assert.Throws<ArgumentNullException>(() => EtlPipeline.Create().JsonSingleStreamExtractor<PersonRecord>((Stream)null!));
+        Assert.Throws<ArgumentNullException>(() => EtlPipeline.Create().JsonSingleStreamExtractor<PersonRecord>((string)null!));
+
+        // Sink terminators.
+        Assert.Throws<ArgumentNullException>(() => ((IEtlPipeline<PersonRecord>)null!).JsonLineLoader<PersonRecord>("x"));
+        Assert.Throws<ArgumentNullException>(() => pipeline.JsonLineLoader<PersonRecord>((Stream)null!));
+        Assert.Throws<ArgumentNullException>(() => ((IEtlPipeline<PersonRecord>)null!).JsonSingleStreamLoader<PersonRecord>("x"));
+        Assert.Throws<ArgumentNullException>(() => pipeline.JsonSingleStreamLoader<PersonRecord>((string)null!));
+        Assert.Throws<ArgumentNullException>(() => pipeline.JsonSingleStreamLoader<PersonRecord>((Stream)null!));
+    }
+
+
+    private static async Task<List<T>> Collect<T>(IAsyncEnumerable<T> items)
+    {
+        var list = new List<T>();
+        await foreach (var item in items)
+        {
+            list.Add(item);
+        }
+
+        return list;
     }
 
 


### PR DESCRIPTION
## Summary

Fixes what the **v0.5.0 release gate (#241)** caught once #62 was merged into vNext — three distinct problems:

### 1. Production bug — `JsonSingleStreamLoader(Stream)` disposed the caller's stream
The stream-based sink terminator wrongly wrapped the sink in `.DisposingOwned(stream)`, disposing the **caller's** stream after `RunAsync` (a copy-paste slip from the path overload). Stream overloads must leave lifetime to the caller. → now `pipeline.To(loader)`.

### 2. Compile error on .NET Framework
The cross-shape test used `string.Split('\n', StringSplitOptions.RemoveEmptyEntries)` — a **.NET-Core-only** overload → CS1503 on net462/47/48. This broke CodeQL, InspectCode, and every Windows/Linux build that compiles the netfx TFMs. → `char[]` overload.

### 3. Coverage gaps
The original #62 tests never exercised the JsonSingleStream path/stream factories, the loader overloads, the explicit-`options` branches, or most null guards. Expanded `EtlPipelineJsonExtensionsTests`:
- `SinkExtensions` 41% → ≥90%
- `SourceExtensions` 61% → ≥90%
- `JsonSingleStreamExtractor` 82% → ≥90%

## Test plan
- [x] 446 unit tests pass (net8.0), incl. the new coverage tests
- [x] Full multi-TFM build clean (net462 → net10.0)
- [x] All `Wolfgang.Etl.Json` modules ≥90% line coverage locally
- [ ] #241 (release: v0.5.0) Stage 1 coverage gate + CodeQL + InspectCode green once this lands on vNext

Once merged into vNext, #241 re-runs and should finally go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)