### PR TITLE
fix: JsonMetricsTests thread-safety (net10.0 'Collection was modified' race)

### DIFF
--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMetricsTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMetricsTests.cs
@@ -27,10 +27,8 @@ public sealed class JsonMetricsTests
     private sealed class MetricsCollector : IDisposable
     {
         private readonly MeterListener _listener = new();
-
-        public List<string> Counters { get; } = new();
-
-        public List<string> Histograms { get; } = new();
+        private readonly List<string> _counters = new();
+        private readonly List<string> _histograms = new();
 
         public MetricsCollector()
         {
@@ -44,21 +42,40 @@ public sealed class JsonMetricsTests
 
             _listener.SetMeasurementEventCallback<long>((instrument, _, _, _) =>
             {
-                lock (Counters)
+                lock (_counters)
                 {
-                    Counters.Add(instrument.Name);
+                    _counters.Add(instrument.Name);
                 }
             });
 
             _listener.SetMeasurementEventCallback<double>((instrument, _, _, _) =>
             {
-                lock (Histograms)
+                lock (_histograms)
                 {
-                    Histograms.Add(instrument.Name);
+                    _histograms.Add(instrument.Name);
                 }
             });
 
             _listener.Start();
+        }
+
+        // Reads must hold the same lock as the callbacks' writes: the listener fires on other
+        // threads (including measurements from tests running in parallel), so an unlocked
+        // enumeration can race with an Add and throw "Collection was modified".
+        public bool CounterRecorded(string name)
+        {
+            lock (_counters)
+            {
+                return _counters.Contains(name);
+            }
+        }
+
+        public bool HistogramRecorded(string name)
+        {
+            lock (_histograms)
+            {
+                return _histograms.Contains(name);
+            }
         }
 
         public void Dispose() => _listener.Dispose();
@@ -79,9 +96,9 @@ public sealed class JsonMetricsTests
         {
         }
 
-        Assert.Contains("wolfgang.etl.json.items.extracted", collector.Counters);
-        Assert.Contains("wolfgang.etl.json.items.skipped", collector.Counters);
-        Assert.Contains("wolfgang.etl.json.operation.duration", collector.Histograms);
+        Assert.True(collector.CounterRecorded("wolfgang.etl.json.items.extracted"));
+        Assert.True(collector.CounterRecorded("wolfgang.etl.json.items.skipped"));
+        Assert.True(collector.HistogramRecorded("wolfgang.etl.json.operation.duration"));
     }
 
 
@@ -93,8 +110,8 @@ public sealed class JsonMetricsTests
 
         await loader.LoadAsync(Source());
 
-        Assert.Contains("wolfgang.etl.json.items.loaded", collector.Counters);
-        Assert.Contains("wolfgang.etl.json.operation.duration", collector.Histograms);
+        Assert.True(collector.CounterRecorded("wolfgang.etl.json.items.loaded"));
+        Assert.True(collector.HistogramRecorded("wolfgang.etl.json.operation.duration"));
     }
 
 


### PR DESCRIPTION
## Summary

The last blocker on the **v0.5.0 release (#241)** — Stage 1 failed on **net10.0 only** (passing on net5–9): my #244 `JsonMetricsTests.Extractor_emits_…` threw `InvalidOperationException: Collection was modified; enumeration operation may not execute.`

### Cause
`MeterListener` callbacks fire on **other threads**, and the subscription is by meter name — so it also captures measurements from **tests running in parallel**. `Assert.Contains(collector.Counters, …)` enumerated the backing `List` while a callback was `Add`-ing to it. net10.0's timing surfaced the race; net5–9 happened not to hit it. (My earlier local run was net8.0-only, so I missed it.)

### Fix
Replaced the public `List` properties with `CounterRecorded(name)` / `HistogramRecorded(name)` methods that read under the **same lock** the callbacks write under. Test-only change.

## Test plan
- [x] **446/446 on net10.0 across 3 consecutive runs** (the previously-failing TFM)
- [x] Full suite green
- [ ] #241 Stage 1 → Stage 2/3 → all required checks green once this lands on vNext

Once merged to vNext, #241 re-runs; this should be the last fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)