### PR TITLE
Adopt Abstractions #84 error handling + 0.18.0 renames (JsonLineExtractor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.0] - 2026-07-22
+## [0.5.0] - 2026-07-25
 
 ### Added
 
@@ -38,8 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bumped the `Wolfgang.Etl.Abstractions` dependency from 0.15.0 to 0.16.0, required by the fluent
-  `EtlPipeline` JSON factories.
+- Bumped the `Wolfgang.Etl.Abstractions` dependency from 0.15.0 to 0.18.0 (0.16.0 for the fluent
+  `EtlPipeline` JSON factories; 0.18.0 for the #84 per-item error-handling mechanism).
+- `JsonLineExtractor`'s error handling now flows through the Abstractions #84 policy: the existing
+  `ErrorHandling` knob (`Throw` / `CaptureAndContinue` / `SkipAndLog`) is translated to the base
+  `ItemErrorAction` via `OnItemError`, and a skipped record is counted in `CurrentErrorItemCount`
+  and surfaced in the pipeline's `ErrorItemCount`. Behaviour is unchanged for existing callers.
+- **Breaking:** `JsonDeserializationError` now exposes a single 1-based `ItemNumber` locator (the
+  JSONL line number, stream number, or item position) plus `RawContent` and `Exception` — the
+  previous `ItemIndex` and `LineNumber` properties (shipped in 0.4.0) are removed. The whole-document
+  extractors' ordinal shifts from 0-based to 1-based for consistency.
 
 ## [0.4.0] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.0] - 2026-07-25
+## [0.6.0] - 2026-07-25
+
+Minor release: adopts the `Wolfgang.Etl.Abstractions` #84 per-item error-handling mechanism in
+`JsonLineExtractor`.
+
+### Changed
+
+- Bumped `Wolfgang.Etl.Abstractions` 0.16.0 → 0.18.0 for the #84 per-item error-handling mechanism.
+- `JsonLineExtractor`'s error handling now flows through the Abstractions #84 policy: the existing
+  `ErrorHandling` knob (`Throw` / `CaptureAndContinue` / `SkipAndLog`) is translated to the base
+  `ItemErrorAction` via `OnItemError`; a skipped record is counted in `CurrentErrorItemCount` and
+  surfaced in the pipeline's `ErrorItemCount`. Behaviour is unchanged for existing callers.
+- **Breaking:** `JsonDeserializationError` now exposes a single 1-based `ItemNumber` locator (the
+  JSONL line number, stream number, or item position) plus `RawContent` and `Exception` — the
+  previous `ItemIndex` and `LineNumber` properties (shipped in 0.4.0) are removed. The whole-document
+  extractors' ordinal shifts from 0-based to 1-based for consistency.
+
+## [0.5.0] - 2026-07-22
 
 ### Added
 
@@ -38,16 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bumped the `Wolfgang.Etl.Abstractions` dependency from 0.15.0 to 0.18.0 (0.16.0 for the fluent
-  `EtlPipeline` JSON factories; 0.18.0 for the #84 per-item error-handling mechanism).
-- `JsonLineExtractor`'s error handling now flows through the Abstractions #84 policy: the existing
-  `ErrorHandling` knob (`Throw` / `CaptureAndContinue` / `SkipAndLog`) is translated to the base
-  `ItemErrorAction` via `OnItemError`, and a skipped record is counted in `CurrentErrorItemCount`
-  and surfaced in the pipeline's `ErrorItemCount`. Behaviour is unchanged for existing callers.
-- **Breaking:** `JsonDeserializationError` now exposes a single 1-based `ItemNumber` locator (the
-  JSONL line number, stream number, or item position) plus `RawContent` and `Exception` — the
-  previous `ItemIndex` and `LineNumber` properties (shipped in 0.4.0) are removed. The whole-document
-  extractors' ordinal shifts from 0-based to 1-based for consistency.
+- Bumped the `Wolfgang.Etl.Abstractions` dependency from 0.15.0 to 0.16.0, required by the fluent
+  `EtlPipeline` JSON factories.
 
 ## [0.4.0] - 2026-07-15
 

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget-local" value="C:\nuget-local" />
+  </packageSources>
+</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget-local" value="C:\nuget-local" />
-  </packageSources>
-</configuration>

--- a/src/Wolfgang.Etl.Json/JsonDeserializationError.cs
+++ b/src/Wolfgang.Etl.Json/JsonDeserializationError.cs
@@ -7,27 +7,23 @@ public sealed class JsonDeserializationError
 {
     internal JsonDeserializationError
     (
-        long itemIndex,
-        long? lineNumber,
+        long itemNumber,
         string? rawContent,
         Exception exception
     )
     {
-        ItemIndex = itemIndex;
-        LineNumber = lineNumber;
+        ItemNumber = itemNumber;
         RawContent = rawContent;
         Exception = exception;
     }
 
 
 
-    /// <summary>The zero-based index of the item in the extraction sequence.</summary>
-    public long ItemIndex { get; }
-
-
-
-    /// <summary>The line number in the source, if applicable (JSONL only).</summary>
-    public long? LineNumber { get; }
+    /// <summary>
+    /// The 1-based ordinal of the failed item within the extraction — the line number for JSONL,
+    /// or the item's position for a single- or multi-stream source.
+    /// </summary>
+    public long ItemNumber { get; }
 
 
 

--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -329,8 +329,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
         }
 
         var error = new JsonDeserializationError(
-            itemIndex: _errors.Count + CurrentItemCount + CurrentSkippedItemCount + CurrentErrorItemCount,
-            lineNumber: context.ItemNumber,
+            itemNumber: context.ItemNumber,
             rawContent: context.RawContent?.Invoke(),
             exception: context.Exception);
 

--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -330,7 +330,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
 
         var error = new JsonDeserializationError(
             itemIndex: _errors.Count + CurrentItemCount + CurrentSkippedItemCount + CurrentErrorItemCount,
-            lineNumber: context.RecordNumber,
+            lineNumber: context.ItemNumber,
             rawContent: context.RawContent?.Invoke(),
             exception: context.Exception);
 
@@ -339,7 +339,7 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
             _errors.Add(error);
         }
 
-        JsonLogMessages.DeserializationErrorAtLine(_logger, context.RecordNumber, context.Exception);
+        JsonLogMessages.DeserializationErrorAtLine(_logger, context.ItemNumber, context.Exception);
         return ItemErrorAction.Skip;
     }
 

--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -312,10 +312,17 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
     /// <see cref="ItemErrorAction.Skip"/> — or <see cref="ItemErrorAction.Abort"/> for
     /// <see cref="ErrorHandling.Throw"/>. The base then counts the skip in <c>CurrentErrorItemCount</c>.
     /// </summary>
-    // context is guaranteed non-null: the base HandleItemError validates it before calling this.
-#pragma warning disable CA1062
+    /// <param name="context">Describes the failed item. Never <see langword="null"/> via the base caller.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
     protected override ItemErrorAction OnItemError(ItemErrorContext context)
     {
+        // Stryker disable once all: defensive — HandleItemError (the sole caller) already validates
+        // this; the guard exists only to stay safe if a future caller bypasses it.
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
         if (ErrorHandling == ErrorHandling.Throw)
         {
             return ItemErrorAction.Abort;
@@ -335,7 +342,6 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
         JsonLogMessages.DeserializationErrorAtLine(_logger, context.RecordNumber, context.Exception);
         return ItemErrorAction.Skip;
     }
-#pragma warning restore CA1062
 
 
 

--- a/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonLineExtractor.cs
@@ -306,6 +306,39 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
 
 
 
+    /// <summary>
+    /// Translates <see cref="ErrorHandling"/> into the base error-handling contract (#84): captures
+    /// the failure (when <see cref="ErrorHandling.CaptureAndContinue"/>), logs it, and returns
+    /// <see cref="ItemErrorAction.Skip"/> — or <see cref="ItemErrorAction.Abort"/> for
+    /// <see cref="ErrorHandling.Throw"/>. The base then counts the skip in <c>CurrentErrorItemCount</c>.
+    /// </summary>
+    // context is guaranteed non-null: the base HandleItemError validates it before calling this.
+#pragma warning disable CA1062
+    protected override ItemErrorAction OnItemError(ItemErrorContext context)
+    {
+        if (ErrorHandling == ErrorHandling.Throw)
+        {
+            return ItemErrorAction.Abort;
+        }
+
+        var error = new JsonDeserializationError(
+            itemIndex: _errors.Count + CurrentItemCount + CurrentSkippedItemCount + CurrentErrorItemCount,
+            lineNumber: context.RecordNumber,
+            rawContent: context.RawContent?.Invoke(),
+            exception: context.Exception);
+
+        if (ErrorHandling == ErrorHandling.CaptureAndContinue)
+        {
+            _errors.Add(error);
+        }
+
+        JsonLogMessages.DeserializationErrorAtLine(_logger, context.RecordNumber, context.Exception);
+        return ItemErrorAction.Skip;
+    }
+#pragma warning restore CA1062
+
+
+
     private StreamReader CreateStreamReader()
     {
 #if NETSTANDARD2_0 || NET462 || NET481
@@ -468,14 +501,13 @@ public sealed class JsonLineExtractor<TRecord> : ExtractorBase<TRecord, JsonRepo
         catch (JsonException ex)
 #pragma warning restore CA1031
         {
-            if (ErrorHandling == ErrorHandling.Throw) { throw; }
-            var error = new JsonDeserializationError(
-                itemIndex: _errors.Count + CurrentItemCount + CurrentSkippedItemCount,
-                lineNumber: lineNum,
-                rawContent: line,
-                exception: ex);
-            if (ErrorHandling == ErrorHandling.CaptureAndContinue) { _errors.Add(error); }
-            JsonLogMessages.DeserializationErrorAtLine(_logger, lineNum, ex);
+            // Defer the policy (throw / capture / skip) to the base #84 mechanism: OnItemError
+            // records + decides, HandleItemError counts the skip. The worker only owns the catch.
+            if (HandleItemError(new ItemErrorContext(lineNum, ex, () => line)) == ItemErrorAction.Abort)
+            {
+                throw;
+            }
+
             item = default;
             return false;
         }

--- a/src/Wolfgang.Etl.Json/JsonMultiStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonMultiStreamExtractor.cs
@@ -479,8 +479,7 @@ public sealed class JsonMultiStreamExtractor<TRecord> : ExtractorBase<TRecord, J
             }
 
             var error = new JsonDeserializationError(
-                itemIndex: streamIndex,
-                lineNumber: null,
+                itemNumber: streamIndex + 1,
                 rawContent: null,
                 exception: deserializationEx!);
             if (ErrorHandling == ErrorHandling.CaptureAndContinue) { _errors.Add(error); }

--- a/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
+++ b/src/Wolfgang.Etl.Json/JsonSingleStreamExtractor.cs
@@ -335,8 +335,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
         }
 
         var error = new JsonDeserializationError(
-            itemIndex: _errors.Count + CurrentItemCount + CurrentSkippedItemCount,
-            lineNumber: null,
+            itemNumber: _errors.Count + CurrentItemCount + CurrentSkippedItemCount + 1,
             rawContent: null,
             exception: ex);
         if (ErrorHandling == ErrorHandling.CaptureAndContinue)
@@ -344,7 +343,7 @@ public sealed class JsonSingleStreamExtractor<TRecord> : ExtractorBase<TRecord, 
             _errors.Add(error);
         }
 
-        JsonLogMessages.DeserializationErrorAtIndex(_logger, error.ItemIndex, ex);
+        JsonLogMessages.DeserializationErrorAtIndex(_logger, error.ItemNumber, ex);
     }
 
 

--- a/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
+++ b/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.5.0</Version>
+    <Version>0.6.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +

--- a/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
+++ b/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.16.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.18.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.9" />
     <PackageReference Include="System.Text.Json" Version="10.0.9" />

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonLineExtractorTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonLineExtractorTests.cs
@@ -510,7 +510,7 @@ public class JsonLineExtractorTests
         Assert.Single(sut.Errors);
         Assert.IsType<JsonException>(sut.Errors[0].Exception);
         Assert.Equal("not-valid-json", sut.Errors[0].RawContent);
-        Assert.Equal(2L, sut.Errors[0].LineNumber);
+        Assert.Equal(2L, sut.Errors[0].ItemNumber);
     }
 
 

--- a/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMultiStreamExtractorTests.cs
+++ b/tests/Wolfgang.Etl.Json.Tests.Unit/JsonMultiStreamExtractorTests.cs
@@ -553,7 +553,7 @@ public class JsonMultiStreamExtractorTests
         Assert.Equal("Bob", results[1].FirstName);
         Assert.Single(sut.Errors);
         Assert.IsType<JsonException>(sut.Errors[0].Exception);
-        Assert.Equal(1L, sut.Errors[0].ItemIndex);
+        Assert.Equal(2L, sut.Errors[0].ItemNumber);
     }
 
 


### PR DESCRIPTION
> ⚠️ **Draft — for review, not mergeable yet.** Depends on **Wolfgang.Etl.Abstractions 0.18.0** (publishes 2026-07-25). Until then CI is red (0.18.0 isn't on nuget.org yet), and the committed **`nuget.config`** (points at a local feed) must be removed before merge.

## Adopt Abstractions #84 per-item error handling + 0.18.0 renames

Reworks `JsonLineExtractor` onto the new Abstractions #84 mechanism and adopts the 0.18.0 API renames.

### Changes
- **#84 adoption** — `JsonLineExtractor`'s error path now flows through the base `HandleItemError` / `OnItemError` policy; the existing `ErrorHandling` knob (`Throw` / `CaptureAndContinue` / `SkipAndLog`) maps to `ItemErrorAction`.
- **CA1062** — replaced the `#pragma warning disable CA1062` on `OnItemError` with an explicit `ArgumentNullException` guard (+ `// Stryker disable once all: defensive` comment + `<exception>` doc).
- **0.18.0 rename** — `context.RecordNumber` → `context.ItemNumber`.
- **Dead-letter simplification (BREAKING)** — `JsonDeserializationError` collapses its two locators (`ItemIndex` + `LineNumber`) into a single 1-based **`ItemNumber`** (+ `RawContent` + `Exception`). Each extractor supplies its natural ordinal — JSONL line #, stream #, item position — so the whole-doc variants shift 0→1-based. Removes members shipped in 0.4.0; pre-1.0, and Json has no PackageValidation gate.

### Release
- Ships as **0.6.0** — a separate version from the in-flight, not-yet-tagged **0.5.0** (fluent EtlPipeline factories, checkpointing, OTel; Abstractions 0.16.0). This PR does not touch 0.5.0; 0.6.0 bumps the dependency to Abstractions 0.18.0.
- **446 unit tests pass** against 0.18.0 (local feed).
- **Pending before merge (tomorrow):** remove the local `nuget.config` once Abstractions 0.18.0 publishes.
- Note: `JsonSingleStreamExtractor` / `JsonMultiStreamExtractor` remain on the pre-#84 error path (#252); this PR migrates `JsonLineExtractor`, but the shared `JsonDeserializationError` simplification touches all three.
