### PR TITLE
#254 PackageValidation gate + track 4 public types in PublicAPI

### DIFF
--- a/src/Wolfgang.Etl.Json/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.Json/PublicAPI.Shipped.txt
@@ -60,3 +60,22 @@ Wolfgang.Etl.Json.JsonSingleStreamLoader<TRecord>.JsonSingleStreamLoader(System.
 Wolfgang.Etl.Json.JsonSingleStreamLoader<TRecord>.JsonSingleStreamLoader(System.IO.Stream stream, System.Text.Json.Serialization.Metadata.JsonTypeInfo<TRecord> typeInfo, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.Json.JsonSingleStreamLoader<TRecord>> logger = null) -> void
 Wolfgang.Etl.Json.JsonSingleStreamLoader<TRecord>.IsDryRun.get -> bool
 Wolfgang.Etl.Json.JsonSingleStreamLoader<TRecord>.IsDryRun.set -> void
+Wolfgang.Etl.Json.ErrorHandling
+Wolfgang.Etl.Json.ErrorHandling.CaptureAndContinue = 1 -> Wolfgang.Etl.Json.ErrorHandling
+Wolfgang.Etl.Json.ErrorHandling.SkipAndLog = 2 -> Wolfgang.Etl.Json.ErrorHandling
+Wolfgang.Etl.Json.ErrorHandling.Throw = 0 -> Wolfgang.Etl.Json.ErrorHandling
+Wolfgang.Etl.Json.JsonDeserializationError
+Wolfgang.Etl.Json.JsonDeserializationError.Exception.get -> System.Exception!
+Wolfgang.Etl.Json.JsonDeserializationError.ItemIndex.get -> long
+Wolfgang.Etl.Json.JsonDeserializationError.LineNumber.get -> long?
+Wolfgang.Etl.Json.JsonDeserializationError.RawContent.get -> string?
+Wolfgang.Etl.Json.EtlPipelineJsonSinkExtensions
+static Wolfgang.Etl.Json.EtlPipelineJsonSinkExtensions.JsonLineLoader<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, System.IO.Stream! stream, System.Text.Json.JsonSerializerOptions? options = null) -> Wolfgang.Etl.Abstractions.IEtlPipelineSink!
+static Wolfgang.Etl.Json.EtlPipelineJsonSinkExtensions.JsonLineLoader<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, string! path, System.Text.Json.JsonSerializerOptions? options = null) -> Wolfgang.Etl.Abstractions.IEtlPipelineSink!
+static Wolfgang.Etl.Json.EtlPipelineJsonSinkExtensions.JsonSingleStreamLoader<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, System.IO.Stream! stream, System.Text.Json.JsonSerializerOptions? options = null) -> Wolfgang.Etl.Abstractions.IEtlPipelineSink!
+static Wolfgang.Etl.Json.EtlPipelineJsonSinkExtensions.JsonSingleStreamLoader<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T>! pipeline, string! path, System.Text.Json.JsonSerializerOptions? options = null) -> Wolfgang.Etl.Abstractions.IEtlPipelineSink!
+Wolfgang.Etl.Json.EtlPipelineJsonSourceExtensions
+static Wolfgang.Etl.Json.EtlPipelineJsonSourceExtensions.JsonLineExtractor<T>(this Wolfgang.Etl.Abstractions.EtlPipeline! pipeline, System.IO.Stream! stream, System.Text.Json.JsonSerializerOptions? options = null) -> Wolfgang.Etl.Abstractions.IEtlPipeline<T>!
+static Wolfgang.Etl.Json.EtlPipelineJsonSourceExtensions.JsonLineExtractor<T>(this Wolfgang.Etl.Abstractions.EtlPipeline! pipeline, string! path, System.Text.Json.JsonSerializerOptions? options = null) -> Wolfgang.Etl.Abstractions.IEtlPipeline<T>!
+static Wolfgang.Etl.Json.EtlPipelineJsonSourceExtensions.JsonSingleStreamExtractor<T>(this Wolfgang.Etl.Abstractions.EtlPipeline! pipeline, System.IO.Stream! stream, System.Text.Json.JsonSerializerOptions? options = null) -> Wolfgang.Etl.Abstractions.IEtlPipeline<T>!
+static Wolfgang.Etl.Json.EtlPipelineJsonSourceExtensions.JsonSingleStreamExtractor<T>(this Wolfgang.Etl.Abstractions.EtlPipeline! pipeline, string! path, System.Text.Json.JsonSerializerOptions? options = null) -> Wolfgang.Etl.Abstractions.IEtlPipeline<T>!

--- a/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
+++ b/src/Wolfgang.Etl.Json/Wolfgang.Etl.Json.csproj
@@ -13,6 +13,11 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <!-- Gate published packages for ABI breaks against the previous release.
+         Keep the baseline at the last PUBLISHED version (not vNext); bump on
+         each release. -->
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.Json</Title>
     <Description>Extractor and Loader implementations for reading and writing JSON, JSONL, and multi-stream JSON files, built on Wolfgang.Etl.Abstractions.</Description>
     <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-Json</PackageProjectUrl>


### PR DESCRIPTION
Stacked on #256 (base upgrade). Closes #254.

## Gap 1 — PackageValidation gate
Enabled `EnablePackageValidation` on the src csproj with `PackageValidationBaselineVersion` pinned to the last published version (**0.5.0**, per the fleet "keep-at-last-published" convention). Published packages are now gated for ABI breaks against the prior release.

## Gap 2 — untracked public types
Added the four public types that were declared in source but missing from the PublicAPI files (silently defeating RS0017 for them):
- `ErrorHandling` (enum)
- `JsonDeserializationError`
- `EtlPipelineJsonSinkExtensions`
- `EtlPipelineJsonSourceExtensions`

Entries follow the existing fleet style (type + meaningful members; compiler-synthesized record plumbing is intentionally untracked — RS0016 is dormant fleet-wide).

## Verification (local, all TFMs net462 → net10.0)
- Build clean, **0 RS00xx** diagnostics
- `dotnet pack` passes **PackageValidation** against the 0.5.0 baseline

> Note: a broader audit surfaced that other v0.4/v0.5 members (checkpointing `StartByteOffset`/`CurrentByteOffset`/`EnableCheckpointing`, extractor `ErrorHandling`/`Errors`) are also untracked. These are out of #254's stated scope, and the error-handling members are being reworked in #252 — left for that PR.

> ⚠️ Shares the #256 CI blocker: restore fails until Abstractions 0.20.0 / TestKit 0.13.0 are on nuget.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)