### PR TITLE
Fix 0.6.0 release: ApiCompat suppressions + CHANGELOG date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [0.6.0] - 2026-08-06
+## [0.6.0] - 2026-08-10
 
 Minor release (pre-1.0 breaking): adopts the per-item error-handling model from
 `Wolfgang.Etl.Abstractions` 0.21+ and retires the parallel local error surface, so a failed record is

--- a/compat-suppressions.txt
+++ b/compat-suppressions.txt
@@ -6,3 +6,11 @@
 #
 # Example:
 #   CP0002: Member 'SomeMethod()' exists in the contract but not in the implementation
+
+# 0.6.0 (#252): intentional removal of the local error-handling surface, replaced
+# by the inherited base ErrorPolicy + the shared Wolfgang.Etl.ErrorPolicies package.
+# These two type-name substrings cover all 11 breaks (the removed types plus the
+# ErrorHandling/Errors get/init members on the three extractors that reference them).
+Wolfgang.Etl.Json.ErrorHandling
+Wolfgang.Etl.Json.JsonDeserializationError
+ErrorHandling.init

--- a/compat-suppressions.txt
+++ b/compat-suppressions.txt
@@ -9,7 +9,7 @@
 
 # 0.6.0 (#252): intentional removal of the local error-handling surface, replaced
 # by the inherited base ErrorPolicy + the shared Wolfgang.Etl.ErrorPolicies package.
-# These two type-name substrings cover all 11 breaks (the removed types plus the
+# These three substrings cover all 11 breaks (the removed types plus the
 # ErrorHandling/Errors get/init members on the three extractors that reference them).
 Wolfgang.Etl.Json.ErrorHandling
 Wolfgang.Etl.Json.JsonDeserializationError


### PR DESCRIPTION
The v0.6.0 release **failed** at the `Pack & Validate NuGet` → **Check ABI compatibility (ApiCompat)** step, so 0.6.0 never published to nuget.org.

**Root cause:** release.yaml runs a custom ApiCompat gate (`scripts/Check-ApiCompatibility.ps1`) that reads **`compat-suppressions.txt`** — a file *separate* from the built-in PackageValidation's `CompatibilitySuppressions.xml`. `compat-suppressions.txt` still had only comment lines, so the 11 intentional #252 removals weren't waived and the gate failed the pack job (before the publish step ran — nothing was published, nothing to yank).

**Fix:** added three substring suppressions to `compat-suppressions.txt` covering all breaks across every TFM. Verified by running the exact script locally against the 0.5.0 baseline → *"no disallowed ABI breaks"*, exit 0.

Also includes: correct the `## [0.6.0]` CHANGELOG date `2026-08-06` → `2026-08-10`.

## Re-release after merge
1. Merge this to `main`.
2. Move the `v0.6.0` tag to the new `main` HEAD (release.yaml runs from the tag commit).
3. Re-publish the v0.6.0 release to re-trigger `release.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)