### PR TITLE
Fix ApiCompat script exit code (0.6.0 release blocker)

### DIFF
--- a/scripts/Check-ApiCompatibility.ps1
+++ b/scripts/Check-ApiCompatibility.ps1
@@ -70,6 +70,7 @@ function Get-PreviousVersion([string]$packageId, [string]$currentVersion) {
 }
 
 $breakingTotal = 0
+$toolErrorTotal = 0
 $projects = Get-ChildItem -Path (Join-Path $repoRoot 'src') -Recurse -Filter '*.csproj'
 
 foreach ($proj in $projects) {
@@ -113,9 +114,22 @@ foreach ($proj in $projects) {
 
         Write-Host "--- $packageId [$tfm]: $prev -> $version ---"
         $raw = & apicompat --left $prevDll --right $curDll 2>&1
+        $apiExit = $LASTEXITCODE
 
-        $breaks = $raw |
-            Where-Object { $_ -match 'CP[0-9]{4}' } |
+        $cpLines = @($raw | Where-Object { $_ -match 'CP[0-9]{4}' })
+
+        # apicompat exits non-zero when it FINDS ABI differences (which we filter /
+        # suppress below). A non-zero exit with NO CP-code output means apicompat
+        # itself failed to run (bad args, crash, missing input) — that must fail the
+        # gate rather than be masked by the success 'exit 0'.
+        if ($apiExit -ne 0 -and $cpLines.Count -eq 0) {
+            Write-Host "  ❌ apicompat failed for [$tfm] (exit $apiExit, no CP-code output — tool error):"
+            $raw | ForEach-Object { Write-Host "     $_" }
+            $toolErrorTotal += 1
+            continue
+        }
+
+        $breaks = $cpLines |
             Where-Object { $line = $_; -not ($suppressions | Where-Object { $line -like "*$_*" }) }
 
         if ($breaks) {
@@ -135,9 +149,16 @@ foreach ($proj in $projects) {
     }
 }
 
+if ($toolErrorTotal -gt 0) {
+    Write-Error "❌ apicompat failed to run for $toolErrorTotal target(s) (tool/internal error, not a suppressible ABI break). See the log above."
+    exit 1
+}
 if ($breakingTotal -gt 0) {
     Write-Error "❌ $breakingTotal unsuppressed ABI break(s) in a non-major release. Bump MAJOR or record intentional breaks in compat-suppressions.txt."
     exit 1
 }
+# Reached only when apicompat ran for every target and left no unsuppressed breaks;
+# force exit 0 so apicompat's non-zero 'differences found' code does not leak through
+# CI's 'pwsh -command' shell (see the tool-error guard above for real failures).
 Write-Host "✅ ApiCompat: no disallowed ABI breaks."
 exit 0

--- a/scripts/Check-ApiCompatibility.ps1
+++ b/scripts/Check-ApiCompatibility.ps1
@@ -140,3 +140,4 @@ if ($breakingTotal -gt 0) {
     exit 1
 }
 Write-Host "✅ ApiCompat: no disallowed ABI breaks."
+exit 0


### PR DESCRIPTION
The v0.6.0 re-release failed **again** at `Pack & Validate NuGet` → `Check ABI compatibility (ApiCompat)` — but this time the check *passed* (`✅ ApiCompat: no disallowed ABI breaks`) and the **step exited 1 anyway**.

**Root cause:** `apicompat` exits non-zero when it *detects* breaks (the intentional #252 removals). `scripts/Check-ApiCompatibility.ps1` suppresses them in its own logic and prints success, but never calls `exit 0` — so under CI's `pwsh -command` shell the process inherits `apicompat`'s leaked `$LASTEXITCODE=1`. My earlier local check used `pwsh -File`, which masked it — the **second** dry-run gap in this release, now closed.

**Fix:** explicit `exit 0` on the success path (the failure path already `exit 1`s). Verified with the CI-exact invocation `pwsh -Command ./scripts/Check-ApiCompatibility.ps1 -Configuration Release` → **exit 0**.

This is the first ETL-Json release to actually *suppress* ABI breaks (compat-suppressions.txt was empty before), so the latent bug surfaced now.

## Re-release after merge (same as before)
1. Merge to main.
2. Move `v0.6.0` tag to the new main HEAD.
3. Draft-toggle the release to re-fire `release: published`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)